### PR TITLE
Include IP in user context

### DIFF
--- a/src/class-wp-sentry-tracker-base.php
+++ b/src/class-wp-sentry-tracker-base.php
@@ -61,7 +61,6 @@ abstract class WP_Sentry_Tracker_Base {
 		$user_context = [
 			'id'         => 0,
 			'name'       => 'anonymous',
-			'ip_address' => isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : '',
 		];
 
 		// Determine whether the user is logged in assign their details.
@@ -74,6 +73,11 @@ abstract class WP_Sentry_Tracker_Base {
 					'username' => $current_user->user_login,
 				];
 			}
+		}
+
+		// Add client IP address if available
+		if ( !empty( $_SERVER['REMOTE_ADDR'] ) ) {
+			$user_context['ip_address'] = $_SERVER['REMOTE_ADDR'];
 		}
 
 		// Filter the user context so that plugins that manage users on their own

--- a/src/class-wp-sentry-tracker-base.php
+++ b/src/class-wp-sentry-tracker-base.php
@@ -59,8 +59,9 @@ abstract class WP_Sentry_Tracker_Base {
 
 		// Default user context to anonymous.
 		$user_context = [
-			'id'   => 0,
-			'name' => 'anonymous',
+			'id'         => 0,
+			'name'       => 'anonymous',
+			'ip_address' => $_SERVER['REMOTE_ADDR'],
 		];
 
 		// Determine whether the user is logged in assign their details.

--- a/src/class-wp-sentry-tracker-base.php
+++ b/src/class-wp-sentry-tracker-base.php
@@ -59,8 +59,8 @@ abstract class WP_Sentry_Tracker_Base {
 
 		// Default user context to anonymous.
 		$user_context = [
-			'id'         => 0,
-			'name'       => 'anonymous',
+			'id'   => 0,
+			'name' => 'anonymous',
 		];
 
 		// Determine whether the user is logged in assign their details.

--- a/src/class-wp-sentry-tracker-base.php
+++ b/src/class-wp-sentry-tracker-base.php
@@ -61,7 +61,7 @@ abstract class WP_Sentry_Tracker_Base {
 		$user_context = [
 			'id'         => 0,
 			'name'       => 'anonymous',
-			'ip_address' => $_SERVER['REMOTE_ADDR'],
+			'ip_address' => isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : '',
 		];
 
 		// Determine whether the user is logged in assign their details.


### PR DESCRIPTION
Currently the server IP is used for all events, which is not helpful in some situations.

(sorry for the many commits, it’s good now)