### PR TITLE
Extracted beforeSend function from options object

### DIFF
--- a/public/sentry-browser-5.6.3.min.js
+++ b/public/sentry-browser-5.6.3.min.js
@@ -38,6 +38,9 @@ var Sentry=function(n){var t=function(n,r){return(t=Object.setPrototypeOf||{__pr
         if (typeof wp_sentry.beforeSend !== 'undefined') {
             wp_sentry.beforeSend = jsonFunctionParse(wp_sentry.beforeSend);
         }
+        if (typeof wp_sentry.beforeBreadcrumb !== 'undefined') {
+            wp_sentry.beforeBreadcrumb = jsonFunctionParse(wp_sentry.beforeBreadcrumb);
+        }
 
         Sentry.init(wp_sentry);
 

--- a/public/sentry-browser-5.6.3.min.js
+++ b/public/sentry-browser-5.6.3.min.js
@@ -22,11 +22,21 @@ var Sentry=function(n){var t=function(n,r){return(t=Object.setPrototypeOf||{__pr
             }
         };
 
+        var jsonFunctionParse = function (stringFunction) {
+            if (typeof Function === 'function')  {
+                return Function('"use strict";return (' + stringFunction + ')')();
+            })
+            return eval('(' + stringFunction + ')');
+        }
+
         if (typeof wp_sentry.whitelistUrls === 'object') {
             regexListUrls(wp_sentry.whitelistUrls);
         }
         if (typeof wp_sentry.blacklistUrls === 'object') {
             regexListUrls(wp_sentry.blacklistUrls);
+        }
+        if (typeof wp_sentry.beforeSend !== 'undefined') {
+            wp_sentry.beforeSend = jsonFunctionParse(wp_sentry.beforeSend);
         }
 
         Sentry.init(wp_sentry);


### PR DESCRIPTION
I wanted to include beforeSend filter into options and sadly `eval` was the only solution that I could use with current structure.

I did try avoiding `eval` by using `Function`, which is sadly unsupported in older browsers.

Reason for pull request is also mentioned in  #41 .