### PR TITLE
Switch to guzzle6-adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "php": "^7.1",
     "sentry/sentry": "^2.4",
     "composer/installers": "^1.0",
-    "php-http/curl-client": "^2.0",
+    "php-http/guzzle6-adapter": "^2.0",
     "http-interop/http-factory-guzzle": "^1.0"
   },
   "config": {

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,8 @@
   },
   "require": {
     "php": "^7.1",
-    "sentry/sentry": "^2.4",
-    "composer/installers": "^1.0",
-    "php-http/guzzle6-adapter": "^2.0",
-    "http-interop/http-factory-guzzle": "^1.0"
+    "sentry/sdk": "^2.1",
+    "composer/installers": "^1.0"
   },
   "config": {
     "platform": {


### PR DESCRIPTION
As per https://github.com/getsentry/sentry-php-sdk/commit/18921af9c2777517ef9fb480845c22a98554d6af
Related to https://github.com/getsentry/sentry-php/issues/1039

Notes:
* Sorry, I can't run a composer update to get a matching `composer.lock` file
* Is there a reason for not using `sentry/sdk` package?