### PR TITLE
Add ability to define functions from PHP to JS

### DIFF
--- a/public/wp-sentry-browser.min.js
+++ b/public/wp-sentry-browser.min.js
@@ -38,6 +38,26 @@ var Sentry=function(t){var n=function(t,r){return(n=Object.setPrototypeOf||{__pr
             }
         }
 
+        // Check for options that are intended to be functions
+        var functionRegex = /^(function)(\[[\w\s,]+\])?:/mi;
+        for (var wpSentryKey in wp_sentry) {
+            if(typeof wp_sentry[wpSentryKey] === "string") {
+                var matches = wp_sentry[wpSentryKey].match(functionRegex);
+                if(matches) {
+                    var functionCode = wp_sentry[wpSentryKey].substring(matches[0].length);
+                    var functionArguments = [];
+                    if(matches[2]) {
+                        var found_arguments = matches[2].substring(1, matches[2].length - 1).split(',');
+                        for(var ii  = 0; ii < found_arguments.length; ii++) {
+                            functionArguments.push(found_arguments[ii].trim());
+                        }
+                    }
+
+                    wp_sentry[wpSentryKey] = new Function(functionArguments, functionCode);
+                }
+            }
+        }
+
         Sentry.init(wp_sentry);
 
         if (typeof wp_sentry.context === 'object') {

--- a/wp-sentry.iml
+++ b/wp-sentry.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/wp-sentry.iml
+++ b/wp-sentry.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>


### PR DESCRIPTION
Some JS sentry options are callback functions which currently cannot be configured with this plugin.

This code will check the options in the wp_sentry object and similar to the 'regex' implementation, it will check for strings starting with a 'function:' or 'function[param1, param2]:'. It will then use the JS native Function to convert the string to a function call.

In the case of the second approach(function[param1, param2])- it will define the arguments you expect the function to be called with, otherwise with the first approach you can simply used arguments[0]... etc. 

The PHP defining the options looks like this (using the second approach):

"beforeSend" => "function[event,hint]:
     const error = hint.originalException;
     if(error && error.message) {
        if(error.message.match(/grecaptcha is not defined/i)) {
            return null;
        }
        if(error.message.match(/Non-Error promise rejection captured with value: .*/i)) {
            return null;
        }
     }
     return event;
    ",

Whereas with the first approach, not defining arguments, looks like this:

"beforeSend" => "function:
     const event = arguments[0];
     const hint = arguments[1];
     const error = hint.originalException;
     if(error && error.message) {
        if(error.message.match(/grecaptcha is not defined/i)) {
            return null;
        }
        if(error.message.match(/Non-Error promise rejection captured with value: .*/i)) {
            return null;
        }
     }
     return event;
    ",


I was considering defining a full JS and parsing out the params etc- but this seemed easiest option however if you reckon that approach might be better let me know.
