### PR TITLE
Support loading wp-sentry.php as part of wp-config.php

### DIFF
--- a/src/class-wp-sentry-php-tracker.php
+++ b/src/class-wp-sentry-php-tracker.php
@@ -130,7 +130,7 @@ final class WP_Sentry_Php_Tracker {
 
 		return [
 			'wordpress' => $wp_version,
-			'language'  => get_bloginfo( 'language' ),
+			'language'  => function_exists( 'get_bloginfo' ) ? get_bloginfo( 'language' ) : 'unknown',
 			'php'       => phpversion(),
 		];
 	}

--- a/src/class-wp-sentry-php-tracker.php
+++ b/src/class-wp-sentry-php-tracker.php
@@ -125,8 +125,11 @@ final class WP_Sentry_Php_Tracker {
 	 * @return array
 	 */
 	public function get_default_tags(): array {
+		// Include an unmodified $wp_version.
+		require ABSPATH . '/wp-includes/version.php';
+
 		return [
-			'wordpress' => get_bloginfo( 'version' ),
+			'wordpress' => $wp_version,
 			'language'  => get_bloginfo( 'language' ),
 			'php'       => phpversion(),
 		];

--- a/wp-sentry.php
+++ b/wp-sentry.php
@@ -96,7 +96,7 @@ if ( defined( 'WP_SENTRY_BROWSER_DSN' ) || defined( 'WP_SENTRY_PUBLIC_DSN' ) ) {
 }
 
 // Load the admin page when needed
-if ( is_admin() ) {
+if ( function_exists( 'is_admin' ) && is_admin() ) {
 	WP_Sentry_Admin_Page::get_instance();
 }
 


### PR DESCRIPTION
The readme already mentions that you can load the plugin file with a must-use plugin to catch more errors. I'd like to go a step further and load the plugin file as part of `wp-config.php` to also catch errors during the WordPress bootstrap process.

Loading the plugin that early means that some WordPress functions may not exist yet. Luckily, the plugin doesn't depend on so many functions and each used function can be adjusted to make it work.

The simplified code for `wp-config.php` may look like this:

```php
// Load the WordPress plugin API early so hooks can be used.
require_once ABSPATH . '/wp-includes/plugin.php';

// Load WP Sentry plugin
require_once ABSPATH . '/wp-content/plugins/wp-sentry-integration/wp-sentry.php';
define( 'WP_SENTRY_MU_LOADED', true );
```

We first have to require the WordPress plugin API to make functions like `add_action()` available. That's not a big deal and fully supported by WordPress, see [here](https://core.trac.wordpress.org/ticket/36819) and [here](https://core.trac.wordpress.org/ticket/37707)).

For the plugin itself we only have to make sure that two functions exist: `is_admin()` and `get_bloginfo()`.
* For `is_admin()` I added a simple `function_exists()` check in https://github.com/stayallive/wp-sentry/commit/1829c45acd50250f57fa8964e793bcecdc65e131. 
* `get_bloginfo( 'version' )` can (and should) be replaced with using the version from `version.php`. This makes sure we use an unmodified WordPress version which is always available. Done in https://github.com/stayallive/wp-sentry/commit/2b00f96fc4f39e05023c2dd9c0dadc1774cac9d8.
* There's no such replacement for `get_bloginfo( 'language' )` so I used a `function_exist()` check in https://github.com/stayallive/wp-sentry/commit/b370b8d66a92f762e3eee45acea243fd20bc44a0 too.

I'm aware that this is some advanced usage but since the changes are minimal I thought I submit this PR anyway. Let me know what you think!