### PR TITLE
Allow loading the plugin in wp-config.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,20 @@ if (function_exists('wp_sentry_safe')) {
 
 If you need to add data to the scope in every case use `configureScope` in [wp_sentry_scope filter](#wp_sentry_scope-void).
 
+### Loading Sentry before WordPress
+
+Since WP Sentry is a WordPress plugin it loads after WordPress and unless you are using a must-use plugin (see [Capturing plugin errors](#capturing-plugin-errors)) even after some other plugins loaded throwing errors which are not captured by Sentry.
+
+To remedy this you can opt to load the plugin from your `wp-config.php` file before WordPress is started.
+
+It's really simple to do this by adding the following snippet to your `wp-config.php` before the `/* That's all, stop editing! Happy blogging. */` comment:
+
+```php
+require_once ABSPATH . '/wp-content/plugins/wp-sentry-integration/wp-sentry.php';
+```
+
+Also make sure that any configuration options like `WP_SENTRY_PHP_DSN` are set before the snippet above otherwise they have no effect.
+
 ### Capturing plugin errors
 
 Since this plugin is called `wp-sentry-integration` it loads a bit late which could miss errors or notices occuring in plugins that load before it.

--- a/README.md
+++ b/README.md
@@ -306,15 +306,14 @@ You can remedy this by loading WordPress Sentry as a must-use plugin by creating
  * License: MIT
  */
 
-$wp_sentry = __DIR__ . '/../plugins/wp-sentry-integration/wp-sentry.php';
+$wp_sentry = ABSPATH . '/plugins/wp-sentry-integration/wp-sentry.php';
 
+// Do not crash in case the plugin is not installed
 if ( ! file_exists( $wp_sentry ) ) {
 	return;
 }
 
 require $wp_sentry;
-
-define( 'WP_SENTRY_MU_LOADED', true );
 ```
 
 Now `wp-sentry-integration` will load always and before all other plugins.

--- a/src/class-wp-sentry-admin-page.php
+++ b/src/class-wp-sentry-admin-page.php
@@ -24,8 +24,14 @@ final class WP_Sentry_Admin_Page {
 	 * WP_Sentry_Admin_Page constructor.
 	 */
 	protected function __construct() {
-		add_action( 'admin_menu', [ $this, 'admin_menu' ] );
-		add_action( 'network_admin_menu', [ $this, 'network_admin_menu' ] );
+		add_action( 'init', function () {
+			if ( ! is_admin() ) {
+				return;
+			}
+
+			add_action( 'admin_menu', [ $this, 'admin_menu' ] );
+			add_action( 'network_admin_menu', [ $this, 'network_admin_menu' ] );
+		} );
 	}
 
 	/**

--- a/wp-sentry.php
+++ b/wp-sentry.php
@@ -10,15 +10,22 @@
  * License: MIT
  */
 
-// Exit if accessed directly.
+// Exit if accessed directly
 defined( 'ABSPATH' ) || exit;
 
-// If the plugin was already loaded as a mu-plugin do not load again.
-if ( defined( 'WP_SENTRY_MU_LOADED' ) ) {
+// If the plugin was already loaded as a mu-plugin or from somewhere else do not load again
+if ( defined( 'WP_SENTRY_MU_LOADED' ) || defined( 'WP_SENTRY_LOADED' ) ) {
 	return;
 }
 
-// Make sure the PHP version is at least 7.2.
+define( 'WP_SENTRY_LOADED', true );
+
+// Load the WordPress plugin API early so hooks can be used even if Sentry is loaded before WordPress
+if ( ! function_exists( 'add_action' ) ) {
+	require_once ABSPATH . '/wp-includes/plugin.php';
+}
+
+// Make sure the PHP version is at least 7.2
 if ( ! defined( 'PHP_VERSION_ID' ) || PHP_VERSION_ID < 70200 ) {
 	if ( is_admin() ) {
 		function wp_sentry_php_version_notice() { ?>
@@ -38,7 +45,7 @@ if ( ! defined( 'PHP_VERSION_ID' ) || PHP_VERSION_ID < 70200 ) {
 	return;
 }
 
-// Resolve the sentry plugin file.
+// Resolve the sentry plugin file
 define( 'WP_SENTRY_PLUGIN_FILE', call_user_func( static function () {
 	global $wp_plugin_paths;
 
@@ -68,7 +75,7 @@ if ( ! class_exists( WP_Sentry_Version::class ) ) {
 	define( 'WP_SENTRY_SCOPED_AUTOLOADER', $scopedAutoloaderExists );
 }
 
-// Define the default version.
+// Define the default version
 if ( ! defined( 'WP_SENTRY_VERSION' ) ) {
 	define( 'WP_SENTRY_VERSION', wp_get_theme()->get( 'Version' ) ?: 'unknown' );
 }
@@ -95,10 +102,8 @@ if ( defined( 'WP_SENTRY_BROWSER_DSN' ) || defined( 'WP_SENTRY_PUBLIC_DSN' ) ) {
 	}
 }
 
-// Load the admin page when needed
-if ( is_admin() ) {
-	WP_Sentry_Admin_Page::get_instance();
-}
+// Load the admin page
+WP_Sentry_Admin_Page::get_instance();
 
 /**
  * Register a "safe" function to call Sentry functions safer in your own code,

--- a/wp-sentry.php
+++ b/wp-sentry.php
@@ -27,20 +27,18 @@ if ( ! function_exists( 'add_action' ) ) {
 
 // Make sure the PHP version is at least 7.2
 if ( ! defined( 'PHP_VERSION_ID' ) || PHP_VERSION_ID < 70200 ) {
-	if ( is_admin() ) {
-		function wp_sentry_php_version_notice() { ?>
-            <div class="error below-h2">
-                <p>
-					<?php printf(
-						'The WordPress Sentry plugin requires at least PHP 7.2. You have %s. WordPress Sentry will not be active unless this is resolved!',
-						PHP_VERSION
-					); ?>
-                </p>
-            </div>
-		<?php }
+	function wp_sentry_php_version_notice() { ?>
+        <div class="error below-h2">
+            <p>
+				<?php printf(
+					'The WordPress Sentry plugin requires at least PHP 7.2. You have %s. WordPress Sentry will not be active unless this is resolved!',
+					PHP_VERSION
+				); ?>
+            </p>
+        </div>
+	<?php }
 
-		add_action( 'admin_notices', 'wp_sentry_php_version_notice' );
-	}
+	add_action( 'admin_notices', 'wp_sentry_php_version_notice' );
 
 	return;
 }


### PR DESCRIPTION
This allows the following code to work from the `wp-config.php`:

```php
require_once ABSPATH . '/wp-content/plugins/wp-sentry-integration/wp-sentry.php';
```

This was coined in #103 by @ocean90.