### PR TITLE
Use `WPINC` to get to `wp-includes` if defined

### DIFF
--- a/src/class-wp-sentry-php-tracker.php
+++ b/src/class-wp-sentry-php-tracker.php
@@ -143,7 +143,7 @@ final class WP_Sentry_Php_Tracker {
 	 * @return array
 	 */
 	public function get_default_tags(): array {
-		require ABSPATH . 'wp-includes/version.php';
+		require WP_SENTRY_WPINC . '/version.php';
 
 		/** @noinspection IssetArgumentExistenceInspection */
 		$tags = [
@@ -179,8 +179,8 @@ final class WP_Sentry_Php_Tracker {
 		}
 
 		$options['in_app_exclude'] = [
-			ABSPATH . 'wp-admin',
-			ABSPATH . 'wp-includes',
+			WP_SENTRY_WPADMIN, // <base>/wp-admin
+			WP_SENTRY_WPINC,   // <base>/wp-includes
 		];
 
 		return $options;

--- a/wp-sentry.php
+++ b/wp-sentry.php
@@ -20,9 +20,12 @@ if ( defined( 'WP_SENTRY_MU_LOADED' ) || defined( 'WP_SENTRY_LOADED' ) ) {
 
 define( 'WP_SENTRY_LOADED', true );
 
+define( 'WP_SENTRY_WPINC', ABSPATH . ( defined( 'WPINC' ) ? WPINC : 'wp-includes' ) );
+define( 'WP_SENTRY_WPADMIN', ABSPATH . 'wp-admin' );
+
 // Load the WordPress plugin API early so hooks can be used even if Sentry is loaded before WordPress
 if ( ! function_exists( 'add_action' ) ) {
-	require_once ABSPATH . 'wp-includes/plugin.php';
+	require_once WP_SENTRY_WPINC . '/plugin.php';
 }
 
 // Make sure the PHP version is at least 7.2


### PR DESCRIPTION
Fixes / supersedes #120.