### PR TITLE
Fix: undefined index: release

### DIFF
--- a/src/class-wp-sentry-php-tracker.php
+++ b/src/class-wp-sentry-php-tracker.php
@@ -168,11 +168,8 @@ final class WP_Sentry_Php_Tracker {
 			'prefixes'         => [ ABSPATH ],
 			'environment'      => $this->get_environment(),
 			'send_default_pii' => defined( 'WP_SENTRY_SEND_DEFAULT_PII' ) && WP_SENTRY_SEND_DEFAULT_PII,
+			'release'          => defined( 'WP_SENTRY_VERSION' ) ? WP_SENTRY_VERSION : '',
 		];
-
-		if ( defined( 'WP_SENTRY_VERSION' ) ) {
-			$options['release'] = WP_SENTRY_VERSION;
-		}
 
 		if ( defined( 'WP_SENTRY_ERROR_TYPES' ) ) {
 			$options['error_types'] = WP_SENTRY_ERROR_TYPES;


### PR DESCRIPTION
Quick fix for `undefined index` notice by setting a default value for `$options['release']`.

---

**Error message**

```
E_NOTICE Undefined index: release
File: /plugins/wp-sentry-integration/src/class-wp-sentry-admin-page.php
Line: 203 
```

---

**Error source**

https://github.com/stayallive/wp-sentry/blob/64afbb3af48ada5b2072cde2e2d5896e10b7fe27/src/class-wp-sentry-admin-page.php#L203
