### PR TITLE
Tracking of SQL queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ define( 'WP_SENTRY_ENV', 'production' );
 (Optionally) track SQL queries.
 
 ```php
-define( 'SAVEQUERIES', true );
+define( 'WP_SENTRY_TRACK_SQL', true );
 ```
 
 ## Filters

--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ define( 'WP_SENTRY_VERSION', 'v4.16.0' );
 define( 'WP_SENTRY_ENV', 'production' );
 ```
 
+(Optionally) track SQL queries.
+
+```php
+define( 'SAVEQUERIES', true );
+```
+
 ## Filters
 
 This plugin provides the following filters to plugin/theme developers.

--- a/src/class-wp-sentry-sql-tracker.php
+++ b/src/class-wp-sentry-sql-tracker.php
@@ -1,0 +1,58 @@
+<?php
+
+use Sentry\Breadcrumb;
+use Sentry\SentrySdk;
+
+/**
+ * WordPress Sentry SQL Tracker.
+ */
+final class WP_Sentry_Sql_Tracker {
+	use WP_Sentry_Resolve_Environment;
+
+	/**
+	 * Holds the class instance.
+	 *
+	 * @var WP_Sentry_Sql_Tracker
+	 */
+	private static $instance;
+
+	/**
+	 * Get the sentry tracker instance.
+	 *
+	 * @return WP_Sentry_Sql_Tracker
+	 */
+	public static function get_instance(): WP_Sentry_Sql_Tracker {
+		return self::$instance ?: self::$instance = new self;
+	}
+
+	/**
+	 * WP_Sentry_Sql_Tracker constructor.
+	 */
+	protected function __construct() {
+		add_action( 'log_query_custom_data', [ $this, 'filter_log_query_custom_data' ], 10, 5 );
+	}
+
+	/**
+	 * Filter for "log_query_custom_data"
+	 *
+	 * @param array $query_data Custom query data.
+	 * @param string $query The query's SQL.
+	 * @param float $query_time Total time spent on the query, in seconds.
+	 * @param string $query_callstack Comma-separated list of the calling functions.
+	 * @param float $query_start Unix timestamp of the time at the start of the query.
+	 *
+	 * @see wpdb::log_query()
+	 *
+	 */
+	public function filter_log_query_custom_data( $query_data, $query, $query_time, $query_callstack, $query_start ): void {
+		SentrySdk::getCurrentHub()->addBreadcrumb( new Breadcrumb(
+			Breadcrumb::LEVEL_INFO,
+			Breadcrumb::TYPE_DEFAULT,
+			'sql.query',
+			$query,
+			[
+				'executionTimeMs' => round( $query_time * 1000, 2 ),
+			]
+		) );
+	}
+}

--- a/wp-sentry.php
+++ b/wp-sentry.php
@@ -93,7 +93,7 @@ if ( defined( 'WP_SENTRY_PHP_DSN' ) || defined( 'WP_SENTRY_DSN' ) ) {
 }
 
 // Load the SQL tracker if query log is enabled
-if ( defined( 'SAVEQUERIES' ) && SAVEQUERIES ) {
+if ( defined( 'WP_SENTRY_TRACK_SQL' ) && WP_SENTRY_TRACK_SQL ) {
 	WP_Sentry_Sql_Tracker::get_instance();
 }
 

--- a/wp-sentry.php
+++ b/wp-sentry.php
@@ -92,6 +92,11 @@ if ( defined( 'WP_SENTRY_PHP_DSN' ) || defined( 'WP_SENTRY_DSN' ) ) {
 	}
 }
 
+// Load the SQL tracker if query log is enabled
+if ( defined( 'SAVEQUERIES' ) && SAVEQUERIES ) {
+	WP_Sentry_Sql_Tracker::get_instance();
+}
+
 // Load the JavaScript tracker if we have a browser/public DSN
 if ( defined( 'WP_SENTRY_BROWSER_DSN' ) || defined( 'WP_SENTRY_PUBLIC_DSN' ) ) {
 	$sentry_js_tracker_dsn = defined( 'WP_SENTRY_BROWSER_DSN' )


### PR DESCRIPTION
If WordPress query log is enabled (constant `SAVEQUERIES`), send query logs to Sentry.  
This is really useful to debug queries that take too much time, are too complex, or can cause errors.  

Similar to https://github.com/getsentry/sentry-laravel/blob/5faaa4133265c430c5c14f9128a1c9e8bd538649/src/Sentry/Laravel/EventHandler.php#L345