### PR TITLE
Fix for plugin path in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ You can remedy this by loading WordPress Sentry as a must-use plugin by creating
  * License: MIT
  */
 
-$wp_sentry = ABSPATH . 'plugins/wp-sentry-integration/wp-sentry.php';
+$wp_sentry = WP_CONTENT_DIR . '/plugins/wp-sentry-integration/wp-sentry.php';
 
 // Do not crash in case the plugin is not installed
 if ( ! file_exists( $wp_sentry ) ) {


### PR DESCRIPTION
This file doesn't exist, because the path is wrong :

```php
$wp_sentry = ABSPATH . 'plugins/wp-sentry-integration/wp-sentry.php';
```

Since it resolves to `/installation-folder/plugins/wp-sentry-integration/wp-sentry.php`, and `wp-content` is missing in this path.

In the case of a MU plugin, it should be

```php
$wp_sentry = WP_CONTENT_DIR . '/plugins/wp-sentry-integration/wp-sentry.php';
```