### PR TITLE
Corrected key name for JS context

### DIFF
--- a/src/class-wp-sentry-js-tracker.php
+++ b/src/class-wp-sentry-js-tracker.php
@@ -75,7 +75,7 @@ final class WP_Sentry_Js_Tracker {
 
 		$options = $this->get_default_options();
 
-		$options['content'] = $context;
+		$options['context'] = $context;
 
 		if ( has_filter( 'wp_sentry_public_options' ) ) {
 			$options = (array) apply_filters( 'wp_sentry_public_options', $options );


### PR DESCRIPTION
After running with this plugin for a while, I noticed that our JavaScript errors were never being associated with any real users. I subsequently discovered that both `wp-sentry-browser.min.js` and `wp-sentry-browser-tracing.min.js` were looking for `wp_sentry.context`, but the `wp_sentry` object was being populated with a key named `content`.