### PR TITLE
Fix deprecated whitelistUrls & blacklistUrls

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Example usage:
 add_filter( 'wp_sentry_public_options', function ( array $options ) {
 	return array_merge( $options, array(
 		'sampleRate' => '0.5',
-		'blacklistUrls' => array(
+		'denyUrls' => array(
 			'https://github.com/',
 			'regex:\\w+\\.example\\.com',
 		),
@@ -217,7 +217,7 @@ add_filter( 'wp_sentry_public_options', function ( array $options ) {
 } );
 ```
 
-**Note:** _Items prefixed with `regex:` in blacklistUrls and whitelistUrls option arrays will be translated into pure RegExp._
+**Note:** _Items prefixed with `regex:` in denyUrls and allowUrls option arrays will be translated into pure RegExp._
 
 #### `wp_sentry_public_context` (array)
 
@@ -417,7 +417,7 @@ You would place the example below in your `wp-config.php` file to make sure it's
 
 ```php
 function wp_sentry_clientbuilder_callback( \Sentry\ClientBuilder $builder ): void {
-    // For example, disabling the default integrations 
+    // For example, disabling the default integrations
 	$builder->getOptions()->setDefaultIntegrations( false );
 }
 

--- a/public/wp-sentry-browser-tracing.min.js
+++ b/public/wp-sentry-browser-tracing.min.js
@@ -22,11 +22,11 @@ var Sentry=function(t){var n=function(t,r){return n=Object.setPrototypeOf||{__pr
             }
         };
 
-        if (typeof wp_sentry.whitelistUrls === 'object') {
-            regexListUrls(wp_sentry.whitelistUrls);
+        if (typeof wp_sentry.allowUrls === 'object') {
+            regexListUrls(wp_sentry.allowUrls);
         }
-        if (typeof wp_sentry.blacklistUrls === 'object') {
-            regexListUrls(wp_sentry.blacklistUrls);
+        if (typeof wp_sentry.denyUrls === 'object') {
+            regexListUrls(wp_sentry.denyUrls);
         }
 
         if (wp_sentry.tracesSampleRate) {

--- a/public/wp-sentry-browser-tracing.wp.js
+++ b/public/wp-sentry-browser-tracing.wp.js
@@ -19,11 +19,11 @@
             }
         };
 
-        if (typeof wp_sentry.whitelistUrls === 'object') {
-            regexListUrls(wp_sentry.whitelistUrls);
+        if (typeof wp_sentry.allowUrls === 'object') {
+            regexListUrls(wp_sentry.allowUrls);
         }
-        if (typeof wp_sentry.blacklistUrls === 'object') {
-            regexListUrls(wp_sentry.blacklistUrls);
+        if (typeof wp_sentry.denyUrls === 'object') {
+            regexListUrls(wp_sentry.denyUrls);
         }
 
         if (wp_sentry.tracesSampleRate) {

--- a/public/wp-sentry-browser.min.js
+++ b/public/wp-sentry-browser.min.js
@@ -22,11 +22,11 @@ var Sentry=function(t){var n=function(t,r){return n=Object.setPrototypeOf||{__pr
             }
         };
 
-        if (typeof wp_sentry.whitelistUrls === 'object') {
-            regexListUrls(wp_sentry.whitelistUrls);
+        if (typeof wp_sentry.allowUrls === 'object') {
+            regexListUrls(wp_sentry.allowUrls);
         }
-        if (typeof wp_sentry.blacklistUrls === 'object') {
-            regexListUrls(wp_sentry.blacklistUrls);
+        if (typeof wp_sentry.denyUrls === 'object') {
+            regexListUrls(wp_sentry.denyUrls);
         }
 
         if (typeof wp_sentry_hook === 'function') {

--- a/public/wp-sentry-browser.wp.js
+++ b/public/wp-sentry-browser.wp.js
@@ -19,11 +19,11 @@
             }
         };
 
-        if (typeof wp_sentry.whitelistUrls === 'object') {
-            regexListUrls(wp_sentry.whitelistUrls);
+        if (typeof wp_sentry.allowUrls === 'object') {
+            regexListUrls(wp_sentry.allowUrls);
         }
-        if (typeof wp_sentry.blacklistUrls === 'object') {
-            regexListUrls(wp_sentry.blacklistUrls);
+        if (typeof wp_sentry.denyUrls === 'object') {
+            regexListUrls(wp_sentry.denyUrls);
         }
 
         if (typeof wp_sentry_hook === 'function') {


### PR DESCRIPTION
First of all, Thanks for this amazing package. 🙇🏼‍♂️  I would like to bring your attention to one deprecated public option.

From v7.x onwards blacklistUrls and whitelistUrls are deprecated.

![Screenshot 2022-08-12 at 1 22 53 PM](https://user-images.githubusercontent.com/6929121/184311288-290403c1-2182-4daa-afc2-ffe2f5202c99.png)

Ref. to latest v7.10.0 sentry-javascript app.js
https://github.com/getsentry/sentry-javascript/blob/5a3ed510ca5fc74efd6bc42f1569adb696619f86/packages/browser/examples/app.js#L39-L42

Ref. PR
https://github.com/getsentry/sentry-javascript/pull/2671/files

Edit:
If you want, I can add backward compatibility code, so no one has to worry about upgrading the package. Please let me know.
Or 
You've to release a new major version.
