### PR TITLE
Ignore more directories and files in exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,13 @@
 * text=auto
 
 # cleanup exported zip
-docs/* export-ignore
+.github export-ignore
+bin export-ignore
+docs export-ignore
 .gitignore export-ignore
 .gitattributes export-ignore
+release-exclude.txt export-ignore
+scoper.inc.php export-ignore
 
 # Make sure we are not marked as a JavaScript project
 public/sentry-browser-*.js linguist-vendored


### PR DESCRIPTION
When you include the plugin via `composer require stayallive/wp-sentry` there are a few files included which are not necessary for production. To keep the dist archive clean I have updated the list of ignored directories and files.

Current archive content:
<img width="326" alt="current files in archive" src="https://user-images.githubusercontent.com/617637/213867261-574dbefa-1c4b-42ac-ae27-efbd9b23232a.png">
(The docs directory is empty.)