### PR TITLE
New feature / filter - Filter events sent to Sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,25 @@ add_filter( 'wp_sentry_options', function ( \Sentry\Options $options ) {
 
 **Note:** _This filter fires on the WordPress `after_setup_theme` action._
 
+---
+
+#### `wp_sentry_before_send`
+
+You can use this filter to select the events to be sent to Sentry / See [doc](https://docs.sentry.io/platforms/php/configuration/filtering/).
+
+Example usage:
+
+```php
+add_filter( 'wp_sentry_before_send', function ( \Sentry\Event $event, ?\Sentry\EventHint $hint ) {
+	// Don't send warning for hello dolly plugin
+	if ( (string) $event->getLevel() === 'warning' && str_contains( $hint->exception->getFile(), 'plugins/hello.php' ) ) {
+		return null;
+	}
+
+	return $event;
+} );
+```
+
 ### Specific to Browser
 
 #### `wp_sentry_public_dsn` (string)

--- a/src/class-wp-sentry-php-tracker.php
+++ b/src/class-wp-sentry-php-tracker.php
@@ -184,6 +184,9 @@ final class WP_Sentry_Php_Tracker {
 				} );
 			},
 			'send_default_pii' => defined( 'WP_SENTRY_SEND_DEFAULT_PII' ) && WP_SENTRY_SEND_DEFAULT_PII,
+			'before_send' => function ( \Sentry\Event $event, ?\Sentry\EventHint $hint ): ?\Sentry\Event {
+				return apply_filters( 'wp_sentry_before_send', $event, $hint );
+			},
 		];
 
 		if ( defined( 'WP_SENTRY_VERSION' ) ) {


### PR DESCRIPTION
Sentry allows you to filter events in its SDK:
https://docs.sentry.io/platforms/php/configuration/filtering/

This would be very useful, because sometimes warnings in the project come from third-party plugins and it's not always possible to patch them.

With the addition of a filter, this gives all the possibilities for advanced users.