### PR TITLE
Return `$options` in `wp_sentry_options` filter usage

### DIFF
--- a/wp-sentry.php
+++ b/wp-sentry.php
@@ -93,6 +93,7 @@ if ( ! defined( 'WP_SENTRY_VERSION' ) && function_exists( 'add_action' ) ) {
 		// The PHP client has probably already been initialized so we need to update the release on the options directly
 		add_filter( 'wp_sentry_options', static function ( Sentry\Options $options ) {
 			$options->setRelease( WP_SENTRY_VERSION );
+
 			return $options;
 		} );
 	}, /* priority: */ 1 );

--- a/wp-sentry.php
+++ b/wp-sentry.php
@@ -93,6 +93,7 @@ if ( ! defined( 'WP_SENTRY_VERSION' ) && function_exists( 'add_action' ) ) {
 		// The PHP client has probably already been initialized so we need to update the release on the options directly
 		add_filter( 'wp_sentry_options', static function ( Sentry\Options $options ) {
 			$options->setRelease( WP_SENTRY_VERSION );
+			return $options;
 		} );
 	}, /* priority: */ 1 );
 }


### PR DESCRIPTION
When the WP_SENTRY_VERSION is not defined, the wp_sentry_options filter doesn't return the $options variable, so when we add a filter after this one, the data is not set correctly.