### PR TITLE
Performance tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,40 @@ define( 'WP_SENTRY_ERROR_TYPES', E_ALL & ~E_DEPRECATED & ~E_NOTICE & ~E_USER_DEP
 
 ### Performance monitoring
 
+#### `WP_SENTRY_TRACES_SAMPLE_RATE` (PHP)
+
+Set the desired sampling rate for performane tracing. Replace `0.3` with your desired sampling rate (`0.3` means sample ~30% of your traffic):
+
+```php
+// https://docs.sentry.io/platforms/php/performance/#configure
+define( 'WP_SENTRY_TRACES_SAMPLE_RATE', 0.3 ); // traces_sample_rate
+```
+
+**Note:** Do not set this constant or set the sample rate to `0.0` to disable the performance monitoring.
+
+#### `WP_SENTRY_TRACING_FEATURES` (PHP)
+
+Enable performance monitoring features by adding this snippet to your `wp-config.php`:
+
+```php
+define( 'WP_SENTRY_TRACING_FEATURES', [
+	'db' => [
+		'spans' => true,
+		'breadcrumbs' => defined( 'SAVEQUERIES' ) && SAVEQUERIES,
+	],
+	'http' => [
+		'spans' => true,
+		'breadcrumbs' => true,
+	],
+	'transients' => [
+		'spans' => true,
+		'breadcrumbs' => true,
+	],
+] );
+```
+
+**Note:** Not configuring this constant will default to the above configuration.
+
 #### `WP_SENTRY_BROWSER_TRACES_SAMPLE_RATE` (Browser)
 
 Enable JavaScript performance tracing by adding this snippet to your `wp-config.php` and replace `0.3` with your desired sampling rate (`0.3` means sample ~30% of your traffic):

--- a/README.md
+++ b/README.md
@@ -139,8 +139,7 @@ define( 'WP_SENTRY_ERROR_TYPES', E_ALL & ~E_DEPRECATED & ~E_NOTICE & ~E_USER_DEP
 
 **Note**: You can set any combination of error types you want, see the [PHP documentation](https://www.php.net/manual/en/errorfunc.constants.php) for more information.
 
-
-### Performance monitoring
+### Set Up Tracing
 
 #### `WP_SENTRY_TRACES_SAMPLE_RATE` (PHP)
 
@@ -150,6 +149,8 @@ Set the desired sampling rate for performane tracing. Replace `0.3` with your de
 // https://docs.sentry.io/platforms/php/performance/#configure
 define( 'WP_SENTRY_TRACES_SAMPLE_RATE', 0.3 ); // traces_sample_rate
 ```
+
+Enabling tracing will also set `SAVEQUERIES`, this can use more memory to save all the executed queries in your environment. If this is not desirable you can disable query tracing by configuring `WP_SENTRY_TRACING_FEATURES`.
 
 **Note:** Do not set this constant or set the sample rate to `0.0` to disable the performance monitoring.
 
@@ -221,6 +222,24 @@ define( 'WP_SENTRY_BROWSER_USE_ES5_BUNDLES', true );
 **Note:** Enabling this also loads a external polyfill resource hosted by [Polyfill.io](https://polyfill.io/v3/) that is required.
 
 **Note:** Enabling this will disable Session Replay if enabled since it has no ES5 compatible bundles.
+
+### Set Up Profiling
+
+#### `WP_SENTRY_PROFILES_SAMPLE_RATE` (PHP)
+
+**Note:** This feature requires the Excimer PHP extension to be installed. See the [Sentry PHP SDK documentation](https://docs.sentry.io/platforms/php/profiling/#configure) for more information.
+
+Sentry's tracing has to be enabled in order for profiling to work. So you also need to configure `WP_SENTRY_TRACES_SAMPLE_RATE` to enable profiling.
+
+Set the desired sampling rate for profiling. Replace `0.3` with your desired sampling rate (`0.3` means sample ~30% of your traffic):
+
+```php
+define( 'WP_SENTRY_TRACES_SAMPLE_RATE', 0.3 ); // traces_sample_rate
+// https://docs.sentry.io/platforms/php/profiling/#configure
+define( 'WP_SENTRY_PROFILES_SAMPLE_RATE', 0.3 ); // profiles_sample_rate
+```
+
+**Note:** Do not set this constant or set the sample rate to `0.0` to disable the performance monitoring.
 
 
 ## Filters

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "composer/installers",
-            "version": "v2.2.0",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "c29dc4b93137acb82734f672c37e029dfbd95b35"
+                "reference": "12fb2dfe5e16183de69e784a7b84046c43d97e8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/c29dc4b93137acb82734f672c37e029dfbd95b35",
-                "reference": "c29dc4b93137acb82734f672c37e029dfbd95b35",
+                "url": "https://api.github.com/repos/composer/installers/zipball/12fb2dfe5e16183de69e784a7b84046c43d97e8e",
+                "reference": "12fb2dfe5e16183de69e784a7b84046c43d97e8e",
                 "shasum": ""
             },
             "require": {
@@ -25,12 +25,12 @@
                 "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "composer/composer": "1.6.* || ^2.0",
-                "composer/semver": "^1 || ^3",
-                "phpstan/phpstan": "^0.12.55",
-                "phpstan/phpstan-phpunit": "^0.12.16",
-                "symfony/phpunit-bridge": "^5.3",
-                "symfony/process": "^5"
+                "composer/composer": "^1.10.27 || ^2.7",
+                "composer/semver": "^1.7.2 || ^3.4.0",
+                "phpstan/phpstan": "^1.11",
+                "phpstan/phpstan-phpunit": "^1",
+                "symfony/phpunit-bridge": "^7.1.1",
+                "symfony/process": "^5 || ^6 || ^7"
             },
             "type": "composer-plugin",
             "extra": {
@@ -87,6 +87,7 @@
                 "cockpit",
                 "codeigniter",
                 "concrete5",
+                "concreteCMS",
                 "croogo",
                 "dokuwiki",
                 "drupal",
@@ -133,7 +134,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/installers/issues",
-                "source": "https://github.com/composer/installers/tree/v2.2.0"
+                "source": "https://github.com/composer/installers/tree/v2.3.0"
             },
             "funding": [
                 {
@@ -149,7 +150,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-20T06:45:11+00:00"
+            "time": "2024-06-24T20:46:46+00:00"
         },
         {
             "name": "composer/package-versions-deprecated",
@@ -824,16 +825,16 @@
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.29.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "21bd091060673a1177ae842c0ef8fe30893114d2"
+                "reference": "ec444d3f3f6505bb28d11afa41e75faadebc10a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/21bd091060673a1177ae842c0ef8fe30893114d2",
-                "reference": "21bd091060673a1177ae842c0ef8fe30893114d2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/ec444d3f3f6505bb28d11afa41e75faadebc10a1",
+                "reference": "ec444d3f3f6505bb28d11afa41e75faadebc10a1",
                 "shasum": ""
             },
             "require": {
@@ -880,7 +881,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -896,20 +897,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.29.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b"
+                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/77fa7995ac1b21ab60769b7323d600a991a90433",
+                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433",
                 "shasum": ""
             },
             "require": {
@@ -960,7 +961,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -976,7 +977,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         }
     ],
     "packages-dev": [],

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: stayallive
 Donate link: https://github.com/sponsors/stayallive
 Tags: sentry, log, logging, error-handler, error-monitoring
-Requires at least: 4.4
+Requires at least: 4.5
 Tested up to: 6.5
 Requires PHP: 7.2
 Stable tag: 7.14.0

--- a/src/class-wp-sentry-admin-page.php
+++ b/src/class-wp-sentry-admin-page.php
@@ -179,7 +179,7 @@ final class WP_Sentry_Admin_Page {
 
 		$php_tracker = WP_Sentry_Php_Tracker::get_instance();
 
-		$enabled_for_php = $php_tracker->enabled();
+		$enabled_for_php = $php_tracker->enabled() || WP_Sentry_Php_Tracker::get_spotlight_enabled();
 
 		$options = $php_tracker->get_default_options();
 

--- a/src/class-wp-sentry-admin-page.php
+++ b/src/class-wp-sentry-admin-page.php
@@ -2,6 +2,8 @@
 
 /**
  * WordPress Sentry Admin Page.
+ *
+ * @internal This class is not part of the public API and may be removed or changed at any time.
  */
 final class WP_Sentry_Admin_Page {
 	/**

--- a/src/class-wp-sentry-admin-page.php
+++ b/src/class-wp-sentry-admin-page.php
@@ -181,6 +181,9 @@ final class WP_Sentry_Admin_Page {
 
 		$enabled_for_php = $php_tracker->enabled() || WP_Sentry_Php_Tracker::get_spotlight_enabled();
 
+		$php_tracing_enabled   = $enabled_for_php && WP_Sentry_Php_Tracing::get_instance()->is_tracing_enabled();
+		$php_profiling_enabled = $enabled_for_php && WP_Sentry_Php_Tracing::get_instance()->is_profiling_enabled();
+
 		$options = $php_tracker->get_default_options();
 
 		$sends_default_pii = defined( 'WP_SENTRY_SEND_DEFAULT_PII' ) && WP_SENTRY_SEND_DEFAULT_PII;
@@ -280,6 +283,38 @@ final class WP_Sentry_Admin_Page {
 						</td>
 					</tr>
 					<tr>
+						<th><?php esc_html_e( 'Tracing', 'wp-sentry' ); ?></th>
+						<td>
+							<fieldset>
+								<label>
+									<input name="wp-sentry-php-tracing-enabled" type="checkbox" id="wp-sentry-php-tracing-enabled" value="0" <?php echo $php_tracing_enabled ? 'checked="checked"' : '' ?> readonly disabled>
+									<?php esc_html_e( 'Enabled', 'wp-sentry' ); ?>
+								</label>
+							</fieldset>
+							<?php if ( ! ( $php_tracing_enabled ) ): ?>
+								<p class="description">
+									<?php echo translate( 'To enable make sure <code>WP_SENTRY_TRACES_SAMPLE_RATE</code> is set.', 'wp-sentry' ); ?>
+								</p>
+							<?php endif; ?>
+						</td>
+					</tr>
+					<tr>
+						<th><?php esc_html_e( 'Profiling', 'wp-sentry' ); ?></th>
+						<td>
+							<fieldset>
+								<label>
+									<input name="wp-sentry-php-profiling-enabled" type="checkbox" id="wp-sentry-php-profiling-enabled" value="0" <?php echo $php_rofiling_enabled ? 'checked="checked"' : '' ?> readonly disabled>
+									<?php esc_html_e( 'Enabled', 'wp-sentry' ); ?>
+								</label>
+							</fieldset>
+							<?php if ( ! ( $php_profiling_enabled ) ): ?>
+								<p class="description">
+									<?php echo translate( 'To enable make sure tracing is enabled and <code>WP_SENTRY_PROFILES_SAMPLE_RATE</code> is set.', 'wp-sentry' ); ?>
+								</p>
+							<?php endif; ?>
+						</td>
+					</tr>
+					<tr>
 						<th>
 							<label><?php esc_html_e( 'Test PHP integration', 'wp-sentry' ); ?></label>
 						</th>
@@ -344,7 +379,7 @@ final class WP_Sentry_Admin_Page {
 						</td>
 					</tr>
 					<tr>
-						<th><?php esc_html_e( 'Performance Monitoring', 'wp-sentry' ); ?></th>
+						<th><?php esc_html_e( 'Tracing', 'wp-sentry' ); ?></th>
 						<td>
 							<fieldset>
 								<label>
@@ -360,7 +395,7 @@ final class WP_Sentry_Admin_Page {
 						</td>
 					</tr>
 					<tr>
-						<th><?php esc_html_e( 'Session Replays', 'wp-sentry' ); ?></th>
+						<th><?php esc_html_e( 'Session Replay', 'wp-sentry' ); ?></th>
 						<td>
 							<fieldset>
 								<label>

--- a/src/class-wp-sentry-php-tracker.php
+++ b/src/class-wp-sentry-php-tracker.php
@@ -180,12 +180,12 @@ final class WP_Sentry_Php_Tracker {
 	 */
 	public function get_default_options(): array {
 		$options = [
-			'dsn'                => $this->get_dsn(),
-			'tags'               => $this->get_default_tags(),
-			'prefixes'           => [ ABSPATH ],
-			'spotlight'          => self::get_spotlight_enabled(),
-			'environment'        => $this->get_environment(),
-			'before_send'        => function ( Event $event, ?EventHint $hint ): ?Event {
+			'dsn'                  => $this->get_dsn(),
+			'tags'                 => $this->get_default_tags(),
+			'prefixes'             => [ ABSPATH ],
+			'spotlight'            => self::get_spotlight_enabled(),
+			'environment'          => $this->get_environment(),
+			'before_send'          => function ( Event $event, ?EventHint $hint ): ?Event {
 				// Sync the transaction name with the current transaction if we have detected one
 				if ( $event->getTransaction() === null ) {
 					$transaction_name = WP_Sentry_Php_Tracing::get_instance()->get_transaction_name();
@@ -213,7 +213,7 @@ final class WP_Sentry_Php_Tracker {
 
 				return $event;
 			},
-			'integrations'       => static function ( array $integrations ) {
+			'integrations'         => static function ( array $integrations ) {
 				return array_filter( $integrations, static function ( $integration ) {
 					// Disable the modules integration as it only lists the internal packages from this plugin instead of the packages of the full project
 					if ( $integration instanceof ModulesIntegration ) {
@@ -223,8 +223,9 @@ final class WP_Sentry_Php_Tracker {
 					return true;
 				} );
 			},
-			'send_default_pii'   => defined( 'WP_SENTRY_SEND_DEFAULT_PII' ) && WP_SENTRY_SEND_DEFAULT_PII,
-			'traces_sample_rate' => defined( 'WP_SENTRY_TRACES_SAMPLE_RATE' ) ? WP_SENTRY_TRACES_SAMPLE_RATE : null,
+			'send_default_pii'     => defined( 'WP_SENTRY_SEND_DEFAULT_PII' ) && WP_SENTRY_SEND_DEFAULT_PII,
+			'traces_sample_rate'   => defined( 'WP_SENTRY_TRACES_SAMPLE_RATE' ) ? WP_SENTRY_TRACES_SAMPLE_RATE : null,
+			'profiles_sample_rate' => defined( 'WP_SENTRY_PROFILES_SAMPLE_RATE' ) ? WP_SENTRY_PROFILES_SAMPLE_RATE : null,
 		];
 
 		if ( defined( 'WP_SENTRY_VERSION' ) ) {

--- a/src/class-wp-sentry-php-tracker.php
+++ b/src/class-wp-sentry-php-tracker.php
@@ -186,6 +186,15 @@ final class WP_Sentry_Php_Tracker {
 			'spotlight'          => self::get_spotlight_enabled(),
 			'environment'        => $this->get_environment(),
 			'before_send'        => function ( Event $event, ?EventHint $hint ): ?Event {
+				// Sync the transaction name with the current transaction if we have detected one
+				if ( $event->getTransaction() === null ) {
+					$transaction_name = WP_Sentry_Php_Tracing::get_instance()->get_transaction_name();
+
+					if ( $transaction_name !== null ) {
+						$event->setTransaction( $transaction_name );
+					}
+				}
+
 				if ( function_exists( 'apply_filters' ) ) {
 					try {
 						/**

--- a/src/tracing/class-wp-sentry-php-tracing.php
+++ b/src/tracing/class-wp-sentry-php-tracing.php
@@ -1,0 +1,249 @@
+<?php
+
+use GuzzleHttp\Psr7\ServerRequest;
+use Sentry\SentrySdk;
+use Sentry\State\HubInterface;
+use Sentry\Tracing\SpanContext;
+use Sentry\Tracing\SpanStatus;
+use Sentry\Tracing\TransactionSource;
+use function Sentry\continueTrace;
+
+/**
+ * WordPress Sentry PHP Tracing.
+ *
+ * @internal This class is not part of the public API and may be removed or changed at any time.
+ */
+final class WP_Sentry_Php_Tracing {
+	use WP_Sentry_Tracks_Pushed_Scopes_And_Spans;
+
+	/** @var class-string[] */
+	private const FEATURES = [
+		WP_Sentry_Tracing_Feature_DB::class,
+		WP_Sentry_Tracing_Feature_HTTP::class,
+		WP_Sentry_Tracing_Feature_Transients::class,
+	];
+
+	/** @var WP_Sentry_Php_Tracing|null */
+	private static $instance;
+
+	public static function get_instance(): WP_Sentry_Php_Tracing {
+		return self::$instance ?: self::$instance = new self;
+	}
+
+	/** @var \Sentry\Tracing\Transaction|null */
+	private $transaction;
+
+	/** @var \Sentry\Tracing\Span|null */
+	private $bootstrapSpan;
+
+	/** @var \Sentry\Tracing\Span|null */
+	private $appSpan;
+
+	private function __construct() {
+		$hub = WP_Sentry_Php_Tracker::get_instance()->get_client();
+
+		if ( $hub->getClient() !== null ) {
+			$options = $hub->getClient()->getOptions();
+
+			if ( $options->isTracingEnabled() || $options->isSpotlightEnabled() ) {
+				$this->start_transaction( $hub );
+				$this->register_hooks();
+			}
+		}
+	}
+
+	private function start_transaction( HubInterface $sentry ): bool {
+		if ( $this->transaction !== null ) {
+			return false;
+		}
+
+		$requestStartTime = $_SERVER['REQUEST_TIME_FLOAT'] ?? microtime( true );
+
+		$request = ServerRequest::fromGlobals();
+
+		$context = continueTrace(
+			$request->getHeaderLine( 'sentry-trace' ) ?: $request->getHeaderLine( 'traceparent' ),
+			$request->getHeaderLine( 'baggage' )
+		);
+
+		$requestPath = '/' . ltrim( $request->getUri()->getPath(), '/' );
+
+		$context->setOp( 'http.server' );
+		$context->setName( $requestPath );
+		$context->setSource( TransactionSource::url() );
+		$context->setStartTimestamp( $requestStartTime );
+
+		$context->setData( [
+			'url'                 => $requestPath,
+			'http.request.method' => strtoupper( $request->getMethod() ),
+		] );
+
+		$transaction = $sentry->startTransaction( $context );
+
+		SentrySdk::getCurrentHub()->setSpan( $transaction );
+
+		$this->transaction = $transaction;
+
+		if ( $transaction->getSampled() === true ) {
+			$initSpanContext = new SpanContext;
+			$initSpanContext->setOp( 'app.bootstrap' );
+			$initSpanContext->setStartTimestamp( $transaction->getStartTimestamp() );
+
+			$this->bootstrapSpan = $transaction->startChild( $initSpanContext );
+
+			SentrySdk::getCurrentHub()->setSpan( $this->bootstrapSpan );
+		}
+
+		return true;
+	}
+
+	private function register_hooks(): void {
+		if ( $this->transaction === null || $this->transaction->getSampled() === false ) {
+			return;
+		}
+
+		add_filter( 'status_header', [ $this, 'handle_status_header' ], 9999, 2 );
+
+		add_filter( 'rest_dispatch_request', [ $this, 'handle_rest_dispatch_request' ], 9999, 4 );
+
+		add_action( 'wp_loaded', [ $this, 'handle_wp_loaded' ] );
+
+		add_action( 'parse_request', [ $this, 'handle_parse_request' ] );
+
+		add_action( 'shutdown', [ $this, 'handle_shutdown' ] );
+
+		foreach ( self::FEATURES as $feature ) {
+			new $feature();
+		}
+	}
+
+	public function handle_wp_loaded(): void {
+		if ( $this->bootstrapSpan !== null ) {
+			$this->bootstrapSpan->finish();
+		}
+
+		$appContextStart = new SpanContext;
+		$appContextStart->setOp( 'wp.handle' );
+		$appContextStart->setStartTimestamp( $this->bootstrapSpan ? $this->bootstrapSpan->getEndTimestamp() : microtime( true ) );
+
+		$this->appSpan = $this->transaction->startChild( $appContextStart );
+
+		SentrySdk::getCurrentHub()->setSpan( $this->appSpan );
+
+		$this->bootstrapSpan = null;
+
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+			$this->set_transaction_name( "/wp-admin/admin-ajax.php?action={$_POST['action']}" );
+		}
+	}
+
+	public function handle_status_header( string $status_header, int $code ): string {
+		if ( $this->transaction !== null ) {
+			$this->transaction->setHttpStatus( $code );
+		}
+
+		return $status_header;
+	}
+
+	public function handle_parse_request( WP $request ): void {
+		// We only want to handle the transaction for the frontend
+		if ( is_admin() || is_network_admin() ) {
+			return;
+		}
+
+		// Match the request against the matches rule, but this time we capture the offsets of the capture groups
+		preg_match( "#^{$request->matched_rule}#", $request->request, $matches, PREG_OFFSET_CAPTURE );
+
+		// Parse the matched query into an array, the `query_vars` provided are not in the correct order and we need that
+		// @TODO: Validate that `matched_query` always contains the query params in the correct order
+		parse_str( $request->matched_query, $parsed_query );
+
+		// Start with the original request path as the transaction name
+		$transaction = $request->request;
+
+		// Since the part of the transaction that we are
+		$offset_delta = 0;
+
+		foreach ( array_keys( $parsed_query ) as $query_index => $query_key ) {
+			// Not all matches have a query value, so we need to check if there is one
+			if ( ! isset( $matches[ $query_index + 1 ] ) ) {
+				break;
+			}
+
+			[ $query_value, $query_offset ] = $matches[ $query_index + 1 ];
+
+			$placeholder = "{{$query_key}}";
+
+			$transaction = substr_replace( $transaction, $placeholder, $offset_delta + (int) $query_offset, strlen( $query_value ) );
+
+			$offset_delta += strlen( $placeholder ) - strlen( $query_value );
+		}
+
+		$this->set_transaction_name( '/' . $transaction );
+	}
+
+	public function handle_rest_dispatch_request( $dispatch_result, WP_REST_Request $request, string $route, array $handler ) {
+		preg_match( "#^{$route}#", $transaction = $request->get_route(), $matches, PREG_OFFSET_CAPTURE );
+
+		$matches = array_filter( $matches, function ( $key ) {
+			return is_string( $key );
+		}, ARRAY_FILTER_USE_KEY );
+
+		$matches = array_map( function ( array $match, string $key ) {
+			$match[2] = $key;
+
+			return $match;
+		}, $matches, array_keys( $matches ) );
+
+		usort( $matches, function ( $a, $b ) {
+			return $a[1] <=> $b[1];
+		} );
+
+		$offset_delta = 0;
+
+		foreach ( $matches as $match ) {
+			[ $value, $offset, $key ] = $match;
+
+			$placeholder = "{{$key}}";
+
+			$transaction = substr_replace( $transaction, $placeholder, $offset_delta + (int) $offset, strlen( $value ) );
+
+			$offset_delta += strlen( $placeholder ) - strlen( $value );
+		}
+
+		$this->set_transaction_name( $transaction );
+
+		return $dispatch_result;
+	}
+
+	public function handle_shutdown(): void {
+		if ( $this->transaction === null ) {
+			return;
+		}
+
+		// We should skip sending the transaction if the response code is 404
+		if ( $this->transaction->getStatus() === SpanStatus::notFound() ) {
+			$this->appSpan     = null;
+			$this->transaction = null;
+
+			return;
+		}
+
+		if ( $this->transaction->getStatus() === null ) {
+			$this->transaction->setHttpStatus( http_response_code() );
+		}
+
+		if ( $this->appSpan !== null ) {
+			$this->appSpan->finish();
+			$this->appSpan = null;
+		}
+
+		$this->transaction->finish();
+		$this->transaction = null;
+	}
+
+	private function set_transaction_name( string $transaction ): void {
+		$this->transaction->setName( $transaction );
+		$this->transaction->getMetadata()->setSource( TransactionSource::route() );
+	}
+}

--- a/src/tracing/class-wp-sentry-php-tracing.php
+++ b/src/tracing/class-wp-sentry-php-tracing.php
@@ -42,17 +42,37 @@ final class WP_Sentry_Php_Tracing {
 	/** @var \Sentry\Tracing\Span|null */
 	private $app_span;
 
+	/** @var bool */
+	private $tracingEnabled;
+
+	/** @var bool */
+	private $profilingEnabled;
+
 	private function __construct() {
+		$this->tracingEnabled   = false;
+		$this->profilingEnabled = false;
+
 		$hub = WP_Sentry_Php_Tracker::get_instance()->get_client();
 
 		if ( $hub->getClient() !== null ) {
 			$options = $hub->getClient()->getOptions();
 
 			if ( $options->isTracingEnabled() || $options->isSpotlightEnabled() ) {
+				$this->tracingEnabled   = true;
+				$this->profilingEnabled = $options->getProfilesSampleRate() > 0;
+
 				$this->start_transaction( $hub );
 				$this->register_hooks();
 			}
 		}
+	}
+
+	public function is_tracing_enabled(): bool {
+		return $this->tracingEnabled;
+	}
+
+	public function is_profiling_enabled(): bool {
+		return $this->profilingEnabled;
 	}
 
 	private function start_transaction( HubInterface $sentry ): bool {

--- a/src/tracing/features/class-wp-sentry-tracing-feature-db.php
+++ b/src/tracing/features/class-wp-sentry-tracing-feature-db.php
@@ -1,13 +1,21 @@
 <?php
 
+use Sentry\Breadcrumb;
 use Sentry\SentrySdk;
 use Sentry\Tracing\SpanContext;
+use function Sentry\addBreadcrumb;
 
 /**
  * @internal This class is not part of the public API and may be removed or changed at any time.
  */
-class WP_Sentry_Tracing_Feature_DB {
+class WP_Sentry_Tracing_Feature_DB extends WP_Sentry_Tracing_Feature {
+	protected const FEATURE_KEY = 'db';
+
 	public function __construct() {
+		if ( ! $this->span_enabled() && ! $this->breadcrumb_enabled( defined( 'SAVEQUERIES' ) && SAVEQUERIES ) ) {
+			return;
+		}
+
 		if ( ! defined( 'SAVEQUERIES' ) ) {
 			define( 'SAVEQUERIES', true );
 		}
@@ -16,20 +24,47 @@ class WP_Sentry_Tracing_Feature_DB {
 	}
 
 	public function handle_log_query_custom_data( array $query_data, string $query, float $query_time, string $query_callstack, float $query_start ): array {
+		if ( $this->span_enabled() ) {
+			$this->handle_span( $query, $query_start, $query_start + $query_time, [
+				'callstack' => $query_callstack,
+			] );
+		}
+
+		if ( $this->breadcrumb_enabled() ) {
+			$this->handle_breadcrumb( $query, $query_time * 1000, [
+				'callstack' => $query_callstack,
+			] );
+		}
+
+		return $query_data;
+	}
+
+	private function handle_span( string $query, float $start_timestamp, float $end_timestamp, array $data ): void {
 		$parentSpan = SentrySdk::getCurrentHub()->getSpan();
 
 		// If there is no sampled span there is no need to handle the event
 		if ( $parentSpan === null || ! $parentSpan->getSampled() ) {
-			return $query_data;
+			return;
 		}
 
 		$context = new SpanContext;
 		$context->setOp( 'db.sql.query' );
+		$context->setData( $data );
 		$context->setDescription( $query );
-		$context->setStartTimestamp( $query_start );
+		$context->setStartTimestamp( $start_timestamp );
 
-		$parentSpan->startChild( $context )->finish( $query_start + $query_time );
+		$parentSpan->startChild( $context )->finish( $end_timestamp );
+	}
 
-		return $query_data;
+	private function handle_breadcrumb( string $query, float $query_time_ms, array $data ): void {
+		$data['executionTimeMs'] = $query_time_ms;
+
+		addBreadcrumb( new Breadcrumb(
+			Breadcrumb::LEVEL_INFO,
+			Breadcrumb::TYPE_DEFAULT,
+			'db.sql.query',
+			$query,
+			$data
+		) );
 	}
 }

--- a/src/tracing/features/class-wp-sentry-tracing-feature-db.php
+++ b/src/tracing/features/class-wp-sentry-tracing-feature-db.php
@@ -1,0 +1,35 @@
+<?php
+
+use Sentry\SentrySdk;
+use Sentry\Tracing\SpanContext;
+
+/**
+ * @internal This class is not part of the public API and may be removed or changed at any time.
+ */
+class WP_Sentry_Tracing_Feature_DB {
+	public function __construct() {
+		if ( ! defined( 'SAVEQUERIES' ) ) {
+			define( 'SAVEQUERIES', true );
+		}
+
+		add_filter( 'log_query_custom_data', [ $this, 'handle_log_query_custom_data' ], 10, 5 );
+	}
+
+	public function handle_log_query_custom_data( array $query_data, string $query, float $query_time, string $query_callstack, float $query_start ): array {
+		$parentSpan = SentrySdk::getCurrentHub()->getSpan();
+
+		// If there is no sampled span there is no need to handle the event
+		if ( $parentSpan === null || ! $parentSpan->getSampled() ) {
+			return $query_data;
+		}
+
+		$context = new SpanContext;
+		$context->setOp( 'db.sql.query' );
+		$context->setDescription( $query );
+		$context->setStartTimestamp( $query_start );
+
+		$parentSpan->startChild( $context )->finish( $query_start + $query_time );
+
+		return $query_data;
+	}
+}

--- a/src/tracing/features/class-wp-sentry-tracing-feature-http.php
+++ b/src/tracing/features/class-wp-sentry-tracing-feature-http.php
@@ -1,0 +1,103 @@
+<?php
+
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\UriInterface;
+use Sentry\SentrySdk;
+use Sentry\Tracing\SpanContext;
+
+/**
+ * @internal This class is not part of the public API and may be removed or changed at any time.
+ */
+class WP_Sentry_Tracing_Feature_HTTP {
+	use WP_Sentry_Tracks_Pushed_Scopes_And_Spans;
+
+	public function __construct() {
+		add_filter( 'pre_http_request', [ $this, 'handle_pre_http_request' ], 9999, 3 );
+		add_action( 'http_api_debug', [ $this, 'handle_http_api_debug' ], 9999, 5 );
+	}
+
+	/** @param false|array|WP_Error $response */
+	public function handle_pre_http_request( $response, array $parsed_args, string $url ) {
+		// We expect the response to be `false` otherwise it was filtered and we should not create a span for that
+		if ( $response !== false ) {
+			return $response;
+		}
+
+		$parentSpan = SentrySdk::getCurrentHub()->getSpan();
+
+		// If there is no sampled span there is no need to handle the event
+		if ( $parentSpan === null || ! $parentSpan->getSampled() ) {
+			return $response;
+		}
+
+		$method     = strtoupper( $parsed_args['method'] );
+		$fullUri    = $this->get_full_uri( $url );
+		$partialUri = $this->get_partial_uri( $fullUri );
+
+		$context = new SpanContext;
+		$context->setOp( 'http.client' );
+		$context->setDescription( $method . ' ' . $partialUri );
+		$context->setData( [
+			'url'                 => $partialUri,
+			// See: https://develop.sentry.dev/sdk/performance/span-data-conventions/#http
+			'http.query'          => $fullUri->getQuery(),
+			'http.fragment'       => $fullUri->getFragment(),
+			'http.request.method' => $method,
+			// @TODO: Figure out how to get the request body size
+			// 'http.request.body.size' => strlen( $parsed_args['body'] ?? '' ),
+		] );
+
+		$this->push_span( $parentSpan->startChild( $context ) );
+
+		return $response;
+	}
+
+	/** @param array|WP_Error $response */
+	public function handle_http_api_debug( $response, string $context, string $class, array $parsed_args, string $url ): void {
+		$span = $this->maybe_pop_span();
+
+		if ( $span === null ) {
+			return;
+		}
+
+		$response = $response['http_response'] ?? null;
+
+		if ( $response instanceof WP_HTTP_Requests_Response ) {
+			$span->setHttpStatus( $response->get_status() );
+			$span->setData( array_merge( $span->getData(), [
+				// See: https://develop.sentry.dev/sdk/performance/span-data-conventions/#http
+				'http.response.status_code' => $response->get_status(),
+				'http.response.body.size'   => strlen( $response->get_data() ),
+			] ) );
+		}
+
+		$span->finish();
+	}
+
+	/**
+	 * Construct a full URI.
+	 *
+	 * @param string $url
+	 *
+	 * @return UriInterface
+	 */
+	private function get_full_uri( string $url ): UriInterface {
+		return new Uri( $url );
+	}
+
+	/**
+	 * Construct a partial URI, excluding the authority, query and fragment parts.
+	 *
+	 * @param UriInterface $uri
+	 *
+	 * @return string
+	 */
+	private function get_partial_uri( UriInterface $uri ): string {
+		return (string) Uri::fromParts( [
+			'scheme' => $uri->getScheme(),
+			'host'   => $uri->getHost(),
+			'port'   => $uri->getPort(),
+			'path'   => $uri->getPath(),
+		] );
+	}
+}

--- a/src/tracing/features/class-wp-sentry-tracing-feature-http.php
+++ b/src/tracing/features/class-wp-sentry-tracing-feature-http.php
@@ -2,42 +2,59 @@
 
 use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\UriInterface;
+use Sentry\Breadcrumb;
 use Sentry\SentrySdk;
 use Sentry\Tracing\SpanContext;
+use function Sentry\addBreadcrumb;
 
 /**
  * @internal This class is not part of the public API and may be removed or changed at any time.
  */
-class WP_Sentry_Tracing_Feature_HTTP {
+class WP_Sentry_Tracing_Feature_HTTP extends WP_Sentry_Tracing_Feature {
 	use WP_Sentry_Tracks_Pushed_Scopes_And_Spans;
 
+	protected const FEATURE_KEY = 'http';
+
 	public function __construct() {
+		if ( ! $this->span_or_breadcrumb_enabled() ) {
+			return;
+		}
+
 		add_filter( 'pre_http_request', [ $this, 'handle_pre_http_request' ], 9999, 3 );
 		add_action( 'http_api_debug', [ $this, 'handle_http_api_debug' ], 9999, 5 );
 	}
 
 	/** @param false|array|WP_Error $response */
 	public function handle_pre_http_request( $response, array $parsed_args, string $url ) {
-		// We expect the response to be `false` otherwise it was filtered and we should not create a span for that
+		// We expect the response to be `false` otherwise it was filtered and we should not process it since it was filtered
 		if ( $response !== false ) {
 			return $response;
 		}
 
-		$parentSpan = SentrySdk::getCurrentHub()->getSpan();
+		if ( $this->span_enabled() ) {
+			$method     = strtoupper( $parsed_args['method'] );
+			$fullUri    = $this->get_full_uri( $url );
+			$partialUri = $this->get_partial_uri( $fullUri );
 
-		// If there is no sampled span there is no need to handle the event
-		if ( $parentSpan === null || ! $parentSpan->getSampled() ) {
-			return $response;
+			$this->handle_span_start( $method . ' ' . $partialUri, [
+				'url'                 => $partialUri,
+				'http.query'          => $fullUri->getQuery(),
+				'http.fragment'       => $fullUri->getFragment(),
+				'http.request.method' => $method,
+			] );
 		}
 
+		return $response;
+	}
+
+	/** @param array|WP_Error $response */
+	public function handle_http_api_debug( $response, string $context, string $class, array $parsed_args, string $url ): void {
 		$method     = strtoupper( $parsed_args['method'] );
 		$fullUri    = $this->get_full_uri( $url );
 		$partialUri = $this->get_partial_uri( $fullUri );
 
-		$context = new SpanContext;
-		$context->setOp( 'http.client' );
-		$context->setDescription( $method . ' ' . $partialUri );
-		$context->setData( [
+		$http_status = 0;
+		$data        = [
 			'url'                 => $partialUri,
 			// See: https://develop.sentry.dev/sdk/performance/span-data-conventions/#http
 			'http.query'          => $fullUri->getQuery(),
@@ -45,53 +62,69 @@ class WP_Sentry_Tracing_Feature_HTTP {
 			'http.request.method' => $method,
 			// @TODO: Figure out how to get the request body size
 			// 'http.request.body.size' => strlen( $parsed_args['body'] ?? '' ),
-		] );
+		];
 
-		$this->push_span( $parentSpan->startChild( $context ) );
+		if ( is_array( $response ) ) {
+			$response = $response['http_response'] ?? null;
 
-		return $response;
+			if ( $response instanceof WP_HTTP_Requests_Response ) {
+				$data['http.response.status_code'] = $http_status = $response->get_status();
+				$data['http.response.body.size']   = strlen( $response->get_data() );
+			}
+		}
+
+		if ( $this->span_enabled() ) {
+			$this->handle_finish_span( $http_status, $data );
+		}
+
+		if ( $this->breadcrumb_enabled() ) {
+			$this->handle_breadcrumb( $data );
+		}
 	}
 
-	/** @param array|WP_Error $response */
-	public function handle_http_api_debug( $response, string $context, string $class, array $parsed_args, string $url ): void {
+	private function handle_span_start( string $description, array $data ): void {
+		$parentSpan = SentrySdk::getCurrentHub()->getSpan();
+
+		// If there is no sampled span there is no need to handle the event
+		if ( $parentSpan === null || ! $parentSpan->getSampled() ) {
+			return;
+		}
+
+		$context = new SpanContext;
+		$context->setOp( 'http.client' );
+		$context->setDescription( $description );
+		$context->setData( $data );
+
+		$this->push_span( $parentSpan->startChild( $context ) );
+	}
+
+	private function handle_finish_span( int $http_status, array $data ): void {
 		$span = $this->maybe_pop_span();
 
 		if ( $span === null ) {
 			return;
 		}
 
-		$response = $response['http_response'] ?? null;
-
-		if ( $response instanceof WP_HTTP_Requests_Response ) {
-			$span->setHttpStatus( $response->get_status() );
-			$span->setData( array_merge( $span->getData(), [
-				// See: https://develop.sentry.dev/sdk/performance/span-data-conventions/#http
-				'http.response.status_code' => $response->get_status(),
-				'http.response.body.size'   => strlen( $response->get_data() ),
-			] ) );
-		}
+		$span->setData( $data );
+		$span->setHttpStatus( $http_status );
 
 		$span->finish();
 	}
 
-	/**
-	 * Construct a full URI.
-	 *
-	 * @param string $url
-	 *
-	 * @return UriInterface
-	 */
+	private function handle_breadcrumb( array $data ): void {
+		addBreadcrumb( new Breadcrumb(
+			Breadcrumb::LEVEL_INFO,
+			Breadcrumb::TYPE_HTTP,
+			'http',
+			null,
+			$data
+		) );
+	}
+
 	private function get_full_uri( string $url ): UriInterface {
 		return new Uri( $url );
 	}
 
-	/**
-	 * Construct a partial URI, excluding the authority, query and fragment parts.
-	 *
-	 * @param UriInterface $uri
-	 *
-	 * @return string
-	 */
 	private function get_partial_uri( UriInterface $uri ): string {
 		return (string) Uri::fromParts( [
 			'scheme' => $uri->getScheme(),

--- a/src/tracing/features/class-wp-sentry-tracing-feature-transients.php
+++ b/src/tracing/features/class-wp-sentry-tracing-feature-transients.php
@@ -1,0 +1,89 @@
+<?php
+
+use Sentry\SentrySdk;
+use Sentry\Tracing\SpanContext;
+
+/**
+ * Creates spans for the following transient API functions:
+ * - get_transient();
+ * - get_site_transient();
+ * - set_transient();
+ * - set_site_transient();
+ * - delete_transient();
+ * - delete_site_transient();
+ *
+ * @internal This class is not part of the public API and may be removed or changed at any time.
+ */
+class WP_Sentry_Tracing_Feature_Transients {
+	use WP_Sentry_Tracks_Pushed_Scopes_And_Spans;
+
+	public function __construct() {
+		add_filter( 'all', [ $this, 'handle_all_filter' ], 9999 );
+
+		add_action( 'setted_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
+		add_action( 'setted_site_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
+
+		add_action( 'deleted_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
+		add_action( 'deleted_site_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
+	}
+
+	public function handle_all_filter( string $hook_name ): void {
+		if ( $this->str_starts_with( $hook_name, 'pre_set_transient_' ) || $this->str_starts_with( $hook_name, 'pre_set_site_transient_' ) ) {
+			// @TODO: This _shouldn't_ be necessary, but it is. Investigate.
+			$this->maybe_finish_current_span();
+
+			$this->maybe_start_new_span( 'cache.put', func_get_args()[2] );
+		} elseif ( $this->str_starts_with( $hook_name, 'pre_transient_' ) || $this->str_starts_with( $hook_name, 'pre_site_transient_' ) ) {
+			// @TODO: This _shouldn't_ be necessary, but it is. Investigate.
+			$this->maybe_finish_current_span();
+
+			$this->maybe_start_new_span( 'cache.get', func_get_args()[2] );
+		} elseif ( $this->str_starts_with( $hook_name, 'delete_transient_' ) || $this->str_starts_with( $hook_name, 'delete_site_transient_' ) ) {
+			// @TODO: This _shouldn't_ be necessary, but it is. Investigate.
+			$this->maybe_finish_current_span();
+
+			$this->maybe_start_new_span( 'cache.remove', func_get_args()[1] );
+		} elseif ( $this->str_starts_with( $hook_name, 'transient_' ) || $this->str_starts_with( $hook_name, 'site_transient_' ) ) {
+			$span = $this->maybe_pop_span();
+
+			if ( $span !== null ) {
+				$span->setData( [
+					// If the transient does not exist, does not have a value, or has expired, then the return value will be false.
+					// See: https://developer.wordpress.org/reference/functions/get_transient/
+					'cache.hit' => func_get_args()[1] !== false,
+				] );
+				$span->finish();
+			}
+		}
+	}
+
+	public function maybe_start_new_span( string $operation, string $key ): void {
+		$parentSpan = SentrySdk::getCurrentHub()->getSpan();
+
+		// If there is no sampled span there is no need to handle the event
+		if ( $parentSpan === null || ! $parentSpan->getSampled() ) {
+			return;
+		}
+
+		$context = new SpanContext;
+		$context->setOp( $operation );
+		$context->setData( [
+			'cache.key' => $key,
+		] );
+		$context->setDescription( $key );
+
+		$this->push_span( $parentSpan->startChild( $context ) );
+	}
+
+	public function maybe_finish_current_span(): void {
+		$span = $this->maybe_pop_span();
+
+		if ( $span !== null ) {
+			$span->finish();
+		}
+	}
+
+	private function str_starts_with( string $haystack, string $needle ): bool {
+		return strpos( $haystack, $needle ) === 0;
+	}
+}

--- a/src/tracing/features/class-wp-sentry-tracing-feature.php
+++ b/src/tracing/features/class-wp-sentry-tracing-feature.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @internal This class is not part of the public API and may be removed or changed at any time.
+ */
+abstract class WP_Sentry_Tracing_Feature {
+	protected const FEATURE_KEY = 'undefined';
+
+	private static $feature_memo = [];
+
+	protected function span_enabled( bool $default = true ): bool {
+		if ( ! defined( 'WP_SENTRY_TRACING_FEATURES' ) ) {
+			return $default;
+		}
+
+		$memo_key = static::FEATURE_KEY . '_spans';
+
+		if ( isset( self::$feature_memo[ $memo_key ] ) ) {
+			return self::$feature_memo[ $memo_key ];
+		}
+
+		$result = defined( 'WP_SENTRY_TRACING_FEATURES' )
+			? WP_SENTRY_TRACING_FEATURES[ static::FEATURE_KEY ]['spans'] ?? $default
+			: $default;
+
+		self::$feature_memo[ $memo_key ] = $result;
+
+		return $result;
+	}
+
+	protected function breadcrumb_enabled( bool $default = true ): bool {
+		$memo_key = static::FEATURE_KEY . '_breadcrumbs';
+
+		if ( isset( self::$feature_memo[ $memo_key ] ) ) {
+			return self::$feature_memo[ $memo_key ];
+		}
+
+		$result = defined( 'WP_SENTRY_TRACING_FEATURES' )
+			? WP_SENTRY_TRACING_FEATURES[ static::FEATURE_KEY ]['breadcrumbs'] ?? $default
+			: $default;
+
+		self::$feature_memo[ $memo_key ] = $result;
+
+		return $result;
+	}
+
+	protected function span_or_breadcrumb_enabled(): bool {
+		return $this->span_enabled() || $this->breadcrumb_enabled();
+	}
+}

--- a/src/tracing/trait-wp-sentry-tracks-pushed-scopes-and-spans.php
+++ b/src/tracing/trait-wp-sentry-tracks-pushed-scopes-and-spans.php
@@ -1,0 +1,68 @@
+<?php
+
+use Sentry\SentrySdk;
+use Sentry\Tracing\Span;
+
+/**
+ * @internal This class is not part of the public API and may be removed or changed at any time.
+ */
+trait WP_Sentry_Tracks_Pushed_Scopes_And_Spans {
+	/**
+	 * Hold the number of times the scope was pushed.
+	 *
+	 * @var int
+	 */
+	private $pushed_scope_count = 0;
+
+	/**
+	 * Hold the stack of parent spans that need to be put back on the scope.
+	 *
+	 * @var array<int, Span|null>
+	 */
+	private $parent_span_stack = [];
+
+	/**
+	 * Hold the stack of current spans that need to be finished still.
+	 *
+	 * @var array<int, Span|null>
+	 */
+	private $current_span_stack = [];
+
+	protected function push_span( Span $span ): void {
+		$hub = SentrySdk::getCurrentHub();
+
+		$this->parent_span_stack[] = $hub->getSpan();
+
+		$hub->setSpan( $span );
+
+		$this->current_span_stack[] = $span;
+	}
+
+	protected function push_scope(): void {
+		SentrySdk::getCurrentHub()->pushScope();
+
+		++ $this->pushed_scope_count;
+	}
+
+	protected function maybe_pop_span(): ?Span {
+		if ( count( $this->current_span_stack ) === 0 ) {
+			return null;
+		}
+
+		$parent = array_pop( $this->parent_span_stack );
+
+		SentrySdk::getCurrentHub()->setSpan( $parent );
+
+		return array_pop( $this->current_span_stack );
+	}
+
+	protected function maybe_pop_scope(): void {
+		if ( $this->pushed_scope_count === 0 ) {
+			return;
+		}
+
+		SentrySdk::getCurrentHub()->popScope();
+
+		-- $this->pushed_scope_count;
+	}
+}

--- a/src/trait-wp-sentry-resolves-environment.php
+++ b/src/trait-wp-sentry-resolves-environment.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @internal This class is not part of the public API and may be removed or changed at any time.
+ */
 trait WP_Sentry_Resolve_Environment {
 	/**
 	 * Retrieve the current environment name from user config or WordPress API.

--- a/src/trait-wp-sentry-resolves-users.php
+++ b/src/trait-wp-sentry-resolves-users.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @internal This class is not part of the public API and may be removed or changed at any time.
+ */
 trait WP_Sentry_Resolve_User {
 	/**
 	 * Retrieve the current user info from WordPress.

--- a/wp-sentry.php
+++ b/wp-sentry.php
@@ -100,13 +100,20 @@ if ( ! defined( 'WP_SENTRY_VERSION' ) && function_exists( 'add_action' ) ) {
 }
 
 // Load the PHP tracker if we have a PHP DSN
-if ( defined( 'WP_SENTRY_PHP_DSN' ) || defined( 'WP_SENTRY_DSN' ) ) {
+if ( defined( 'WP_SENTRY_PHP_DSN' ) || defined( 'WP_SENTRY_DSN' ) || defined( 'WP_SENTRY_SPOTLIGHT' ) ) {
 	$sentry_php_tracker_dsn = defined( 'WP_SENTRY_PHP_DSN' )
 		? WP_SENTRY_PHP_DSN
-		: WP_SENTRY_DSN;
+		: null;
 
-	if ( ! empty( $sentry_php_tracker_dsn ) ) {
+	if ( $sentry_php_tracker_dsn === null ) {
+		$sentry_php_tracker_dsn = defined( 'WP_SENTRY_DSN' )
+			? WP_SENTRY_DSN
+			: null;
+	}
+
+	if ( ! empty( $sentry_php_tracker_dsn ) || WP_Sentry_Php_Tracker::get_spotlight_enabled() ) {
 		WP_Sentry_Php_Tracker::get_instance();
+		WP_Sentry_Php_Tracing::get_instance();
 	}
 }
 


### PR DESCRIPTION
This is a rough draft of performance tracing, things I like to implement:

- [x] Automatic transactions
	- [x] Parameterized transaction names
	- [ ] Finish transaction after request (maybe already working because `shutdown` usage)
- [x] Add support for Spotlight
- [x] Create spans for features
	- [x] DB queries
		- [x] ~~Code location~~ (defer until next)
	- [x] HTTP requests
		- [ ] ~~Code location~~ (defer until next)
	- [x] Transient operations
- [x] Create breadcrumbs for features
	- [x] DB queries
	- [x] HTTP requests
	- [x] Transient operations
- [x] Add settings to configure tracing / breadcrumb features that are enabled
- [ ] Add context about request (think conditionals tab in query monitor)
- [ ] Update docs
	- [x] How to enable
	- [ ] Considerations (CLI, `SAVE_QUERIES` and multi-site URL)
	- [ ] Usage of `trace` helper for custom spans