### PR TITLE
Fix variable name in class-wp-sentry-admin-page.php

### DIFF
--- a/src/class-wp-sentry-admin-page.php
+++ b/src/class-wp-sentry-admin-page.php
@@ -303,7 +303,7 @@ final class WP_Sentry_Admin_Page {
 						<td>
 							<fieldset>
 								<label>
-									<input name="wp-sentry-php-profiling-enabled" type="checkbox" id="wp-sentry-php-profiling-enabled" value="0" <?php echo $php_rofiling_enabled ? 'checked="checked"' : '' ?> readonly disabled>
+									<input name="wp-sentry-php-profiling-enabled" type="checkbox" id="wp-sentry-php-profiling-enabled" value="0" <?php echo $php_profiling_enabled ? 'checked="checked"' : '' ?> readonly disabled>
 									<?php esc_html_e( 'Enabled', 'wp-sentry' ); ?>
 								</label>
 							</fieldset>


### PR DESCRIPTION
Variable $php_profiling_enabled was misspelt as $php_rofiling_enabled. Ironically I discovered the error by looking at the Sentry issues in my site.