### PR TITLE
Fix deprecation notices on WordPress 6.8+

### DIFF
--- a/src/tracing/features/class-wp-sentry-tracing-feature-transients.php
+++ b/src/tracing/features/class-wp-sentry-tracing-feature-transients.php
@@ -29,8 +29,8 @@ class WP_Sentry_Tracing_Feature_Transients extends WP_Sentry_Tracing_Feature {
 		add_filter( 'all', [ $this, 'handle_all_filter' ], 9999 );
 
 		if ( $this->span_enabled() ) {
-			add_action( 'setted_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
-			add_action( 'setted_site_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
+			add_action( 'set_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
+			add_action( 'set_site_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
 
 			add_action( 'deleted_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
 			add_action( 'deleted_site_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );

--- a/src/tracing/features/class-wp-sentry-tracing-feature-transients.php
+++ b/src/tracing/features/class-wp-sentry-tracing-feature-transients.php
@@ -29,8 +29,13 @@ class WP_Sentry_Tracing_Feature_Transients extends WP_Sentry_Tracing_Feature {
 		add_filter( 'all', [ $this, 'handle_all_filter' ], 9999 );
 
 		if ( $this->span_enabled() ) {
-			add_action( 'set_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
-			add_action( 'set_site_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
+			if ( version_compare( $GLOBALS['wp_version'], '6.8', '<' ) ) {
+				add_action( 'setted_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
+				add_action( 'setted_site_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
+			} else {
+				add_action( 'set_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
+				add_action( 'set_site_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
+			}
 
 			add_action( 'deleted_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
 			add_action( 'deleted_site_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );

--- a/src/tracing/features/class-wp-sentry-tracing-feature-transients.php
+++ b/src/tracing/features/class-wp-sentry-tracing-feature-transients.php
@@ -29,12 +29,12 @@ class WP_Sentry_Tracing_Feature_Transients extends WP_Sentry_Tracing_Feature {
 		add_filter( 'all', [ $this, 'handle_all_filter' ], 9999 );
 
 		if ( $this->span_enabled() ) {
-			if ( version_compare( $GLOBALS['wp_version'], '6.8', '<' ) ) {
-				add_action( 'setted_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
-				add_action( 'setted_site_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
-			} else {
+			if ( isset( $GLOBALS['wp_version'] ) && version_compare( $GLOBALS['wp_version'], '6.8.0', '>=' ) ) {
 				add_action( 'set_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
 				add_action( 'set_site_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
+			} else {
+				add_action( 'setted_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
+				add_action( 'setted_site_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );
 			}
 
 			add_action( 'deleted_transient', [ $this, 'maybe_finish_current_span' ], 10, 0 );


### PR DESCRIPTION
See more details in #213.

These changes are needed to make the plugin fully compatible with WP 6.8.