### PR TITLE
Fix "search the issue tracker" link

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -5,7 +5,7 @@ First off, thank you for considering contributing to Sentry for WordPress.
 ### 1. Where do I go from here?
 
 If you've noticed a bug or have a question 
-[search the issue tracker](https://github.com/stayallive/wp-sentry/issues?q=something)
+[search the issue tracker](https://github.com/stayallive/wp-sentry/issues)
 to see if someone else in the community has already created a ticket.
 If not, go ahead and [make one](https://github.com/stayallive/wp-sentry/issues/new)!
 


### PR DESCRIPTION
Current link performs a search for the string "something" which hides more than half of the open issues. Updated to go to the right place.