### PR TITLE
Add Redis Object Cache exception reporting integration

### DIFF
--- a/src/plugins/class-wp-sentry-redis-object-cache-integration.php
+++ b/src/plugins/class-wp-sentry-redis-object-cache-integration.php
@@ -27,9 +27,7 @@ final class WP_Sentry_Redis_Object_Cache_Integration {
      * WP_Sentry_Redis_Object_Cache_Integration constructor.
      */
     protected function __construct() {
-        if ( file_exists( ABSPATH . 'wp-content/plugins/redis-cache/redis-cache.php' ) && file_exists(ABSPATH . 'wp-content/object-cache.php' ) ) {
-            add_action( 'redis_object_cache_error', array( $this, 'handle_redis_cache_failure' ), 10, 2 );
-        }
+        add_action( 'redis_object_cache_error', array( $this, 'handle_redis_cache_failure' ), 10, 2 );
     }
 
     /**

--- a/src/plugins/class-wp-sentry-redis-object-cache-integration.php
+++ b/src/plugins/class-wp-sentry-redis-object-cache-integration.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * WordPress Sentry Redis Object Cache Integration
+ *
+ * @internal This class is not part of the public API and may be removed or changed at any time.
+ */
+final class WP_Sentry_Redis_Object_Cache_Integration {
+
+    /**
+     * Holds the class instance.
+     *
+     * @var WP_Sentry_Redis_Object_Cache_Integration
+     */
+    private static $instance;
+
+    /**
+     * Get the Sentry admin page instance.
+     *
+     * @return WP_Sentry_Redis_Object_Cache_Integration
+     */
+    public static function get_instance(): WP_Sentry_Redis_Object_Cache_Integration {
+        return self::$instance ?: self::$instance = new self;
+    }
+
+    /**
+     * WP_Sentry_Redis_Object_Cache_Integration constructor.
+     */
+    protected function __construct() {
+        if ( file_exists( ABSPATH . 'wp-content/plugins/redis-cache/redis-cache.php' ) && file_exists(ABSPATH . 'wp-content/object-cache.php' ) ) {
+            add_action( 'redis_object_cache_error', array( $this, 'handle_redis_cache_failure' ), 10, 2 );
+        }
+    }
+
+    /**
+     * Capture and send Redis Object Cache failures to Sentry.
+     *
+     * @param \Throwable $e The exception that was thrown.
+     * @param string $message The exception message.
+     * @return void
+     */
+    public function handle_redis_cache_failure($e, $message ) {
+        wp_sentry_safe(
+            function ( \Sentry\State\HubInterface $client ) use ( $e ) {
+                $client->captureException( $e );
+            }
+        );
+    }
+
+}

--- a/src/plugins/class-wp-sentry-redis-object-cache-integration.php
+++ b/src/plugins/class-wp-sentry-redis-object-cache-integration.php
@@ -1,48 +1,50 @@
 <?php
 
+use Sentry\State\HubInterface;
+
 /**
  * WordPress Sentry Redis Object Cache Integration
+ *
+ * @see      https://wordpress.org/plugins/redis-cache/
  *
  * @internal This class is not part of the public API and may be removed or changed at any time.
  */
 final class WP_Sentry_Redis_Object_Cache_Integration {
+	/**
+	 * Holds the class instance.
+	 *
+	 * @var WP_Sentry_Redis_Object_Cache_Integration
+	 */
+	private static $instance;
 
-    /**
-     * Holds the class instance.
-     *
-     * @var WP_Sentry_Redis_Object_Cache_Integration
-     */
-    private static $instance;
+	/**
+	 * Get the Sentry Redis Object Cache Integration instance.
+	 *
+	 * @return WP_Sentry_Redis_Object_Cache_Integration
+	 */
+	public static function get_instance(): WP_Sentry_Redis_Object_Cache_Integration {
+		return self::$instance ?: self::$instance = new self;
+	}
 
-    /**
-     * Get the Sentry admin page instance.
-     *
-     * @return WP_Sentry_Redis_Object_Cache_Integration
-     */
-    public static function get_instance(): WP_Sentry_Redis_Object_Cache_Integration {
-        return self::$instance ?: self::$instance = new self;
-    }
+	/**
+	 * Class constructor.
+	 */
+	protected function __construct() {
+		add_action( 'redis_object_cache_error', [ $this, 'handle_redis_cache_failure' ] );
+	}
 
-    /**
-     * WP_Sentry_Redis_Object_Cache_Integration constructor.
-     */
-    protected function __construct() {
-        add_action( 'redis_object_cache_error', array( $this, 'handle_redis_cache_failure' ), 10, 2 );
-    }
-
-    /**
-     * Capture and send Redis Object Cache failures to Sentry.
-     *
-     * @param \Throwable $e The exception that was thrown.
-     * @param string $message The exception message.
-     * @return void
-     */
-    public function handle_redis_cache_failure($e, $message ) {
-        wp_sentry_safe(
-            function ( \Sentry\State\HubInterface $client ) use ( $e ) {
-                $client->captureException( $e );
-            }
-        );
-    }
-
+	/**
+	 * Fires when an object cache related error occurs.
+	 *
+	 * @param \Throwable $e The exception that was thrown.
+	 *
+	 * @return void
+	 */
+	public function handle_redis_cache_failure( Throwable $e ): void {
+		wp_sentry_safe(
+			static function ( HubInterface $client ) use ( $e ) {
+				$client->captureException( $e );
+			}
+		);
+	}
 }

--- a/wp-sentry.php
+++ b/wp-sentry.php
@@ -123,6 +123,9 @@ if ( defined( 'WP_SENTRY_PHP_DSN' ) || defined( 'WP_SENTRY_DSN' ) || defined( 'W
 
 		// Action Scheduler integration
 		WP_Sentry_Action_Scheduler_Integration::get_instance();
+
+        // Redis Object Cache integration
+        WP_Sentry_Redis_Object_Cache_Integration::get_instance();
 	}
 }
 

--- a/wp-sentry.php
+++ b/wp-sentry.php
@@ -124,8 +124,8 @@ if ( defined( 'WP_SENTRY_PHP_DSN' ) || defined( 'WP_SENTRY_DSN' ) || defined( 'W
 		// Action Scheduler integration
 		WP_Sentry_Action_Scheduler_Integration::get_instance();
 
-        // Redis Object Cache integration
-        WP_Sentry_Redis_Object_Cache_Integration::get_instance();
+		// Redis Object Cache integration
+		WP_Sentry_Redis_Object_Cache_Integration::get_instance();
 	}
 }
 


### PR DESCRIPTION
Refs: https://github.com/rhubarbgroup/redis-cache/issues/605

This adds custom exception integration for the [Redis Object cache Plugin](https://wordpress.org/plugins/redis-cache/)

The action being used is defined in https://github.com/rhubarbgroup/redis-cache/blob/a456c15c9a09269e0418759f644e88b9dc8f9dc0/includes/object-cache.php#L2927

Without this the exception being thrown by the Redis Client (or anything related in that plugin) don't get reported to sentry as it does a `wp_die()` and does not re-throw them so the Worpdress error handler can process it.

For now there is only the thrown exception as a context in there, but maybe this can be improved in a future version of that plugin to give a bit more context.

> [!WARNING]
> I have NOT yet tested this change. But will try to do that in the upcoming days.