### PR TITLE
docs: use `isEqualTo()` method to determine level severity

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,10 +341,14 @@ Example usage:
 ```php
 add_filter( 'wp_sentry_before_send', function ( \Sentry\Event $event, ?\Sentry\EventHint $hint = null ) {
     // Don't send error event with level `warning` for the Hello Dolly example plugin
-    if ( $hint->exception !== null && $event->getLevel() === \Sentry\Severity::warning() && strpos( $hint->exception->getFile(), 'plugins/hello.php' ) !== false ) {
+    if (
+        ( $hint->exception !== null )
+        && $event->getLevel()->isEqualTo( \Sentry\Severity::warning() )
+        && ( strpos( $hint->exception->getFile(), 'plugins/hello.php' ) !== false )
+    ) {
         return null;
     }
-    
+
     return $event;
 }, 2 );
 ```


### PR DESCRIPTION
The identity comparison (`===`) between `$event->getLevel()` and the `\Sentry\Severity` enum always fails.  While an equality comparison (`==`) would work, this operator is usually discouraged.

Fortunately, the Sentry PHP SDK provides the
`\Sentry\Severity->isEqualTo()` method for correct enum value comparison.