### PR TITLE
Allow jean85/pretty-package-versions 2.x (keep 1.x for PHP 7.2/7.3)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "php": "^7.2.5 || ^8.0",
     "sentry/sentry": "^4.18.1",
     "composer/installers": "^1.0 || ^2.0",
-    "jean85/pretty-package-versions": "^1.5"
+    "jean85/pretty-package-versions": "^1.5 || ^2.0"
   },
   "config": {
     "platform": {


### PR DESCRIPTION
### Change

```diff
   "require": {
     "php": "^7.2.5 || ^8.0",
     "sentry/sentry": "^4.18.1",
     "composer/installers": "^1.0 || ^2.0",
-    "jean85/pretty-package-versions": "^1.5"
+    "jean85/pretty-package-versions": "^1.5 || ^2.0"
   }
```

### Why this is safe for wp-sentry's support matrix

`jean85/pretty-package-versions` v2 requires PHP ≥ 7.4; v1 supports PHP ≥ 7.0. wp-sentry's own support matrix is `^7.2.5 || ^8.0`. With the widened constraint:

- On PHP 7.2 / 7.3 → Composer resolves jean85 **1.x** (same as today).
- On PHP ≥ 7.4 → Composer can resolve jean85 **2.x**.

No supported PHP version loses its resolution path; nothing is dropped. The repo's own `config.platform.php: 7.2.5` setting also keeps wp-sentry's local resolution on 1.x, so `composer update` inside this repo produces an unchanged lock graph.

### Why this is safe for the plugin itself

wp-sentry doesn't call `Jean85\PrettyVersions` directly — it's a transitive dependency of `sentry/sentry`. `sentry/sentry ^4.18.1` already accepts both major lines of jean85, so the SDK consumes jean85 and is already compatible with v1 and v2. wp-sentry's `^1.5` cap is the only thing narrowing the resolution downstream.

### Why it helps downstream projects

Modern PHP test toolchains (PHPUnit 11 / Pest 3 / paratest) require `jean85/pretty-package-versions ^2.1.1`. Today, any WordPress project that uses wp-sentry alongside those tools has to maintain an isolated `composer.json` + `vendor/` for tests because the two ranges (`<2.0.0` vs `>=2.1.1`) don't overlap. Widening here lets those projects share a single vendor tree.

### Risk

Runtime: none — jean85 is never reached through wp-sentry's own code paths. The release pipeline (`.github/workflows/wordpress.yml`, PHP 7.3) continues to resolve jean85 1.x on its build matrix.
