### PR TITLE
Add opt-in preconnect hint for the Sentry ingest origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ define('WP_SENTRY_BROWSER_FRONTEND_ENABLED', true); // Add the JavaScript tracke
 
 **Note:** This constant was previously called `WP_SENTRY_PUBLIC_DSN` and is still supported.
 
+#### `WP_SENTRY_BROWSER_PRECONNECT` (Browser)
+
+Emit a `<link rel="preconnect">` resource hint for the Sentry ingest origin (the scheme + host of your browser DSN). This warms the DNS/TLS connection early in `<head>` so the SDK's first event sends faster, and resolves the Lighthouse "Preconnect candidates" audit. Off by default, front end only.
+
+```php
+define( 'WP_SENTRY_BROWSER_PRECONNECT', true );
+```
+
+The hint includes `crossorigin` because the SDK sends events as anonymous cross-origin `fetch` requests; without it the warmed connection would not be reused.
+
 ### Privacy
 
 #### `WP_SENTRY_SEND_DEFAULT_PII`
@@ -401,6 +411,16 @@ Example usage:
 add_filter( 'wp_sentry_public_dsn', function ( $dsn ) {
 	return 'https://<key>@sentry.io/<project>';
 } );
+```
+
+#### `wp_sentry_browser_preconnect` (bool)
+
+Override whether the preconnect resource hint is emitted (defaults to the value of the `WP_SENTRY_BROWSER_PRECONNECT` constant).
+
+Example usage:
+
+```php
+add_filter( 'wp_sentry_browser_preconnect', '__return_true' );
 ```
 
 #### `wp_sentry_public_options` (array)

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: sentry, log, logging, error-handler, error-monitoring
 Requires at least: 4.5
 Tested up to: 7.0
 Requires PHP: 7.2.5
-Stable tag: 8.11.1
+Stable tag: 8.12.0
 License: MIT
 License URI: https://github.com/stayallive/wp-sentry/blob/v8.11.1/LICENSE.md
 
@@ -50,11 +50,18 @@ To track Browser (JavaScript) errors add this snippet to your `wp-config.php` an
     define('WP_SENTRY_BROWSER_LOGIN_ENABLED', true);    // Add the JavaScript tracker to the login page. Default: true
     define('WP_SENTRY_BROWSER_FRONTEND_ENABLED', true); // Add the JavaScript tracker to the front end.  Default: true
 
+    // Optionally emit a preconnect resource hint to the Sentry ingest origin (front end only):
+    define('WP_SENTRY_BROWSER_PRECONNECT', true);       // Speeds up the first event send. Default: false
+
 **Note:** Do not set this constant to disable the Browser (JavaScript) tracker.
 
 _You can find more information and the full documentation: [here](https://github.com/stayallive/wp-sentry/tree/v8.11.1#configuration). The above are the basics._
 
 == Changelog ==
+= 8.12.0 =
+
+* Add `WP_SENTRY_BROWSER_PRECONNECT` to emit a `<link rel="preconnect">` resource hint for the Sentry ingest origin, improving LCP / fixing the Lighthouse "Preconnect candidates" audit
+
 = 8.11.1 =
 
 * Fix fatal error in HTTP tracing when WordPress passes a malformed URL

--- a/src/class-wp-sentry-admin-page.php
+++ b/src/class-wp-sentry-admin-page.php
@@ -178,6 +178,8 @@ final class WP_Sentry_Admin_Page {
 		$js_enabled_on_login = $js_tracker->enabled_on_login_page();
 		$js_enabled_on_front = $js_tracker->enabled_on_frontend_pages();
 
+		$js_preconnect_enabled = $enabled_for_js && $js_tracker->preconnect_enabled();
+
 		$php_tracker = WP_Sentry_Php_Tracker::get_instance();
 
 		$enabled_for_php = $php_tracker->enabled() || WP_Sentry_Php_Tracker::get_spotlight_enabled();
@@ -435,6 +437,23 @@ final class WP_Sentry_Admin_Page {
 							<?php if ( ! $js_feedback_enabled ): ?>
 								<p class="description">
 									<?php echo translate( 'To enable make sure <code>WP_SENTRY_BROWSER_FEEDBACK_OPTIONS</code> is set.', 'wp-sentry' ); ?>
+								</p>
+							<?php endif; ?>
+						</td>
+					</tr>
+					<tr>
+						<th><?php esc_html_e( 'Preconnect Resource Hint', 'wp-sentry' ); ?></th>
+						<td>
+							<fieldset>
+								<label>
+									<input name="wp-sentry-js-preconnect-enabled" type="checkbox" id="wp-sentry-js-preconnect-enabled" value="0" <?php echo $js_preconnect_enabled ? 'checked="checked"' : '' ?> readonly disabled>
+									<?php esc_html_e( 'Enabled', 'wp-sentry' ); ?>
+									(<a href="https://github.com/stayallive/wp-sentry/tree/v<?php echo WP_Sentry_Version::SDK_VERSION; ?>#wp_sentry_browser_preconnect-browser" target="_blank" rel="noopener">documentation</a>)
+								</label>
+							</fieldset>
+							<?php if ( ! $js_preconnect_enabled ): ?>
+								<p class="description">
+									<?php echo translate( 'To enable make sure <code>WP_SENTRY_BROWSER_PRECONNECT</code> is set to true.', 'wp-sentry' ); ?>
 								</p>
 							<?php endif; ?>
 						</td>

--- a/src/class-wp-sentry-js-tracker.php
+++ b/src/class-wp-sentry-js-tracker.php
@@ -34,6 +34,10 @@ final class WP_Sentry_Js_Tracker {
 
 		if ( $this->enabled_on_frontend_pages() ) {
 			add_action( 'wp_enqueue_scripts', [ $this, 'on_enqueue_scripts' ], 0 );
+
+			// Preconnect to the Sentry ingest origin via core's resource-hints
+			// filter (wp_head prio 2, before our scripts) for the LCP win
+			add_filter( 'wp_resource_hints', [ $this, 'add_resource_hints' ], 10, 2 );
 		}
 	}
 
@@ -54,6 +58,37 @@ final class WP_Sentry_Js_Tracker {
 		}
 
 		return $dsn;
+	}
+
+	/**
+	 * Get the origin (scheme://host[:port]) of the browser DSN.
+	 *
+	 * Used for the preconnect resource hint. Null when there is no usable DSN
+	 * or it can't be parsed into a scheme + host.
+	 *
+	 * @return string|null
+	 */
+	public function get_dsn_origin(): ?string {
+		$dsn = $this->get_dsn();
+
+		if ( empty( $dsn ) ) {
+			return null;
+		}
+
+		$parts = wp_parse_url( $dsn );
+
+		if ( empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
+			return null;
+		}
+
+		$origin = "{$parts['scheme']}://{$parts['host']}";
+
+		// keep an explicit non-standard port if the DSN carries one
+		if ( ! empty( $parts['port'] ) ) {
+			$origin .= ":{$parts['port']}";
+		}
+
+		return $origin;
 	}
 
 	/**
@@ -222,6 +257,41 @@ final class WP_Sentry_Js_Tracker {
 		$this->on_enqueue_scripts();
 	}
 
+	/**
+	 * Add a preconnect resource hint for the Sentry ingest origin.
+	 *
+	 * Hooked onto core's wp_resource_hints so the hint prints at wp_head
+	 * priority 2, earlier than the enqueued SDK scripts. That early placement
+	 * is where the LCP win comes from.
+	 *
+	 * @access private
+	 *
+	 * @param array  $urls          Resource hint URLs for the given relation.
+	 * @param string $relation_type The relation type (e.g. preconnect).
+	 *
+	 * @return array
+	 */
+	public function add_resource_hints( array $urls, string $relation_type ): array {
+		if ( $relation_type !== 'preconnect' || ! $this->preconnect_enabled() ) {
+			return $urls;
+		}
+
+		$origin = $this->get_dsn_origin();
+
+		if ( $origin === null ) {
+			return $urls;
+		}
+
+		// crossorigin is required: the SDK sends envelopes as anonymous CORS
+		// fetch() POSTs, which only reuse a connection warmed as anonymous
+		$urls[] = [
+			'href'        => $origin,
+			'crossorigin' => 'anonymous',
+		];
+
+		return $urls;
+	}
+
 	public function enabled(): bool {
 		return ! empty( $this->get_dsn() );
 	}
@@ -262,6 +332,16 @@ final class WP_Sentry_Js_Tracker {
 
 	public function enabled_on_frontend_pages(): bool {
 		return ! defined( 'WP_SENTRY_BROWSER_FRONTEND_ENABLED' ) || WP_SENTRY_BROWSER_FRONTEND_ENABLED;
+	}
+
+	public function preconnect_enabled(): bool {
+		$enabled = defined( 'WP_SENTRY_BROWSER_PRECONNECT' ) && WP_SENTRY_BROWSER_PRECONNECT;
+
+		if ( has_filter( 'wp_sentry_browser_preconnect' ) ) {
+			$enabled = (bool) apply_filters( 'wp_sentry_browser_preconnect', $enabled );
+		}
+
+		return $enabled;
 	}
 
 	public function get_sdk_version(): string {

--- a/src/class-wp-sentry-version.php
+++ b/src/class-wp-sentry-version.php
@@ -5,5 +5,5 @@
  */
 final class WP_Sentry_Version {
 	public const SDK_IDENTIFIER = 'sentry.php.wordpress';
-	public const SDK_VERSION    = '8.11.1';
+	public const SDK_VERSION    = '8.12.0';
 }

--- a/wp-sentry.php
+++ b/wp-sentry.php
@@ -4,7 +4,7 @@
  * Plugin Name:       Sentry for WordPress
  * Plugin URI:        https://github.com/stayallive/wp-sentry
  * Description:       A (unofficial) WordPress plugin to report PHP and JavaScript errors to Sentry.
- * Version:           8.11.1
+ * Version:           8.12.0
  * Requires at least: 4.4
  * Requires PHP:      7.2.5
  * Author:            Alex Bouma


### PR DESCRIPTION
## What

New opt-in `WP_SENTRY_BROWSER_PRECONNECT` constant that emits a `<link rel="preconnect">` for the Sentry ingest origin (scheme + host of the browser DSN, e.g. `https://o4...2.ingest.us.sentry.io`). Off by default, also flippable via a `wp_sentry_browser_preconnect` filter.

## Why

Lighthouse flags the Sentry ingest origin as a preconnect candidate, about 200ms of LCP on the table. We weren't emitting any resource hints, so the browser only opens that connection once the SDK fires its first event. Warming it early in `<head>` gets that time back.

## How it works

- Hooks core's `wp_resource_hints` so the hint lands at `wp_head` priority 2, before our scripts. Earliest spot, best LCP
- Front end only. That's what Lighthouse audits, and the only context `wp_resource_hints` fires in anyway
- Ships `crossorigin`, which is load-bearing not decoration. The SDK sends events as anonymous cross-origin `fetch` POSTs, and browsers pool connections by origin AND credentials mode. No `crossorigin` warms the wrong pool and the hint gets wasted (Lighthouse would then flag it as an unused preconnect)
- No `dns-prefetch` fallback. `preconnect` already does DNS and every browser we care about supports it
- Read-only row on the Sentry admin page, same as every other option

## Config

```php
// opt in
define( 'WP_SENTRY_BROWSER_PRECONNECT', true );
```

Or via filter:

```php
add_filter( 'wp_sentry_browser_preconnect', '__return_true' );
```

## Testing

Set a valid `WP_SENTRY_BROWSER_DSN` plus `define('WP_SENTRY_BROWSER_PRECONNECT', true)`, then:

- View source on a front-end page, the `<link rel="preconnect" ... crossorigin>` shows up near the top of `<head>` ahead of the wp-sentry scripts, host only, no public key
- Flip the constant off > tag gone. Constant on but no DSN > no tag
- Not present in wp-admin or on the login page, by design
- Sentry admin page shows the new "Preconnect Resource Hint" row
- Re-run Lighthouse, Sentry origin no longer shows as a preconnect candidate and no unused-preconnect warning

## Notes

- Bumped to 8.12.0 across the plugin header, `SDK_VERSION`, and the readme Stable tag, plus a changelog entry. Left the hardcoded `v8.11.1` doc links and License URIs for the release tooling
- Docs added to `README.md` and `readme.txt`